### PR TITLE
Energy resource

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,25 @@
 # Engine centered around resources
 Models resource flows between buildings in a factory, should be then usable on client- and serverside
 
+## Overview
+Already working:
+- Resource
+- Energy
+- ResourceProcess
+- Stock
+- ResourceCalculation
+- EnergyCalculation
+- Prosumer
+
+- Economy with Building as Prosumers
+
 # Roadmap
-- solve resource & energy calculations for each game tick
+- solve resource & energy calculations for each game tick ✔
+- build a little idlegame: upgrade buildings (mines & stock) and tech
 - integrate with a persistence layer (git via phlame-data)
 - integrate with a simple UI, can be console based for the start
+- add fleet for trade
+- add combat and more fleet
 
 ## Resource Calculation
 Integral part of the the game engine, calculates
@@ -18,15 +33,18 @@ Integral part of the the game engine, calculates
 `npm run coverage` - Generates a coverage report (should be 100%)
 
 ## Ideas
-For naming the main Entity and/or ValueObject:
+For naming additional Entities and/or ValueObjects:
+- Action & Consequence (after delay), GameUnit, GameEntity
+- Economy, Industry, Construction, Investment, BuildingProcess
+- HeavenlyBody
+- World, Empire
+- Planet, SolarSystem
 - Phlame(Entity|Value|Environment)
-- Economy
-- World
-- Planet
-- Factory <- don't like this one because we might still need a (X|Phlame)ObjectFactory at some point (just for now ValueObjects carry their own factories)
+- Universe and PhlameBlock to collect all state
+
 ### P2P Game networking
 - servers should be able to interact, peer to peer?
 need always-on address services... can we (ab)use github for all of this?
 α - every repo for is its own can be an alpha universe
-Ω - omega universe allows all kinds of (possibly cheated) worlds and empires as long as they stay compatible at the core
+Ω - omega universe allows all kinds of (possibly cheated before played) worlds and empires as long as they stay compatible at the core
 β & γ - beta and gamma universes can be more serious or distantly forked

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,32 @@
+# Engine centered around resources
+Models resource flows between buildings in a factory, should be then usable on client- and serverside
+
+# Roadmap
+- solve resource & energy calculations for each game tick
+- integrate with a persistence layer (git via phlame-data)
+- integrate with a simple UI, can be console based for the start
+
+## Resource Calculation
+Integral part of the the game engine, calculates
+- Resources in factory and its environment
+- Energy and Heat levels
+- Strategy to handle resource shortage
+
+
+## Development
+`npm start` - Runs jest in watch mode, use its `o` mode to run tests concerning recent file changes
+`npm run coverage` - Generates a coverage report (should be 100%)
+
+## Ideas
+For naming the main Entity and/or ValueObject:
+- Phlame(Entity|Value|Environment)
+- Economy
+- World
+- Planet
+- Factory <- don't like this one because we might still need a (X|Phlame)ObjectFactory at some point (just for now ValueObjects carry their own factories)
+### P2P Game networking
+- servers should be able to interact, peer to peer?
+need always-on address services... can we (ab)use github for all of this?
+α - every repo for is its own can be an alpha universe
+Ω - omega universe allows all kinds of (possibly cheated) worlds and empires as long as they stay compatible at the core
+β & γ - beta and gamma universes can be more serious or distantly forked

--- a/src/Building.spec.ts
+++ b/src/Building.spec.ts
@@ -1,27 +1,60 @@
 import { expect } from "chai";
 
-import Building from "./Building";
+import { stock, requirements, prosumption, ResourceLike } from "./examples";
+import Building, { BuildingIdentifier } from "./Building";
+import { ResourceCollection } from "./resources";
+import { SaltyResource, TumbleResource } from "./resources/examples";
 
 describe("Building", () => {
   it("should be console printable", () => {
-    const b = new Building("B");
-    expect(b.toString()).to.eql("Building(B, 0, 1)");
+    const b = new Building<BuildingIdentifier, ResourceLike>("B", requirements, prosumption);
+    expect(b.toString()).to.eql("Building(B, 0, 100%)");
   });
 
-  it("should have resources and buildings", () => {
-    const speed = 0.5;
+  it("should have resources, costs and speed", () => {
+    const speed = 50;
     const level = 5;
-    const building = new Building("Scraper", level, speed);
-    expect(building.toString()).to.eql("Building(Scraper, 5, 0.5)");
-    expect(building.upgraded.toString()).to.eql("Building(Scraper, 6, 0.5)");
-    expect(building.downgraded.toString()).to.eql("Building(Scraper, 4, 0.5)");
-    expect(building.at(1).toString()).to.eql("Building(Scraper, 5, 1)");
+    const building = new Building<BuildingIdentifier, ResourceLike>("Scraper", requirements, prosumption, level, speed);
+    const mine = new Building<BuildingIdentifier, ResourceLike>(1, requirements, prosumption, level, speed);
+    expect(building.toString()).to.eql("Building(Scraper, 5, 50%)");
+    expect(building.upgraded.toString()).to.eql("Building(Scraper, 6, 50%)");
+    expect(building.downgraded.toString()).to.eql("Building(Scraper, 4, 50%)");
+    expect(building.at(100).toString()).to.eql("Building(Scraper, 5, 100%)");
+    expect(() => {
+      expect(building.upgradeCost).to.eql(undefined);
+    }).to.throw("Unknown building requirement, BuildingType: Scraper");
+    expect(() => {
+      expect(building.downgradeCost).to.eql(undefined);
+    }).to.throw("Unknown building requirement, BuildingType: Scraper");
+
+    expect(mine.toString()).to.eql("Building(1, 5, 50%)");
+    expect(mine.upgradeCost).to.eql(ResourceCollection.fromArray([
+      new TumbleResource(683),
+      new SaltyResource(170),
+    ]));
+    expect(mine.downgradeCost).to.eql(ResourceCollection.fromArray([
+      new TumbleResource(341),
+      new SaltyResource(79),
+    ]));
+    expect(mine.upgradeTime).to.eql(20);
+    expect(mine.downgradeTime).to.eql(10);
+  });
+
+  it("should be a prosumer", () => {
+    const b = new Building<BuildingIdentifier, ResourceLike>(12, requirements, prosumption, 1, 50);
+    const bnot = new Building<BuildingIdentifier, ResourceLike>(12, requirements, {}, 1, 0);
+    expect(b.prosumes(stock).toString()).to.eql(
+      "Prosumer(12, 50%, ResourceProcessCollection[15blubbs-5, 0energy+25])",
+    );
+    expect(bnot.prosumes(stock).toString()).to.eql(
+      "Prosumer(12, 0%, ResourceProcessCollection[])",
+    );
   });
 
   it("should ignore over- and underspeed", () => {
-    const b = new Building("B", 1, -2);
-    const b2 = new Building("B", 1, 2);
-    expect(b.toString()).to.eql("Building(B, 1, 0)");
-    expect(b2.toString()).to.eql("Building(B, 1, 1)");
+    const b = new Building<BuildingIdentifier, ResourceLike>("B", requirements, prosumption, 1, -200);
+    const b2 = new Building<BuildingIdentifier, ResourceLike>("B", requirements, prosumption, 1, 200);
+    expect(b.toString()).to.eql("Building(B, 1, 0%)");
+    expect(b2.toString()).to.eql("Building(B, 1, 100%)");
   });
 });

--- a/src/Building.ts
+++ b/src/Building.ts
@@ -1,22 +1,88 @@
+import {
+  ResourceIdentifier,
+  Resource,
+  ResourceProcess,
+  ResourceProcessCollection,
+  Prosumer,
+  Stock,
+} from "./resources";
+import BuildingRequirement from "./BuildingRequirement";
 
-export type BuildingType = string | number; // I'd prefer string, but if we want integer unitIDs...
+export type BuildingIdentifier = number | string;
 
-export default class Building {
+export type LevelToProsumptionFunc = (level: number) => number;
+
+export type ProsumptionEntries<Types extends ResourceIdentifier> = {
+  [Type in Types]?: LevelToProsumptionFunc;
+}
+
+export type ProsumptionLookup<Types extends BuildingIdentifier, ResourceTypes extends ResourceIdentifier> = {
+  [Type in Types]?: ProsumptionEntries<ResourceTypes>;
+}
+
+export type RequirementLookup<Types extends BuildingIdentifier, ResourceTypes extends ResourceIdentifier> = {
+  [Type in Types]?: BuildingRequirement<Types, ResourceTypes>;
+}
+
+export default class Building<BuildingType extends BuildingIdentifier, ResourceType extends ResourceIdentifier> {
+  static BUILD_TIME_DIVISOR = 2500 / 60;
   readonly type: BuildingType;
+
+  // For now we have the full lookup here, might be nicer to encapsulate in a different way?
+  readonly requirements: RequirementLookup<BuildingType, ResourceType>;
+  readonly prosumption: ProsumptionLookup<BuildingType, ResourceType>;
 
   readonly level: number;
 
   readonly speed: number;
 
-  constructor(type: BuildingType, level?: number, speed?: number) {
+  constructor(
+    type: BuildingType,
+    requirements: RequirementLookup<BuildingType, ResourceType>,
+    prosumption: ProsumptionLookup<BuildingType, ResourceType>,
+    level?: number,
+    speed = 100,
+  ) {
     this.type = type;
+    this.requirements = requirements;
+    this.prosumption = prosumption;
     this.level = level || 0;
-    const defaultSpeed = (!speed || speed >= 1) ? 1 : speed;
+    const defaultSpeed = speed >= 100 ? 100 : speed;
     this.speed = defaultSpeed <= 0 ? 0 : defaultSpeed;
   }
 
   protected new(level?: number, speed?: number) {
-    return new Building(this.type, level, speed);
+    return new Building(this.type, this.requirements, this.prosumption, level, speed);
+  }
+
+  get upgradeCost() {
+    const requirement = this.requirements[this.type];
+    if (!requirement) {
+      throw new Error(`Unknown building requirement, BuildingType: ${this.type}`);
+    }
+    return requirement.getUpgradeCost(this.level + 1);
+  }
+
+  get downgradeCost() {
+    const requirement = this.requirements[this.type];
+    if (!requirement) {
+      throw new Error(`Unknown building requirement, BuildingType: ${this.type}`);
+    }
+    return requirement.getDowngradeCost(this.level + 1);
+  }
+
+  get upgradeTime() {
+    return Math.floor(this.upgradeCost
+      .map((resource) => resource.amount)
+      .reduce((sum, amount) => sum + amount, 0)
+      / Building.BUILD_TIME_DIVISOR);
+  }
+
+  get downgradeTime() {
+    return Math.floor(this.downgradeCost
+      .map((resource) => resource.amount)
+      .reduce((sum, amount) => sum + amount, 0)
+      / Building.BUILD_TIME_DIVISOR);
   }
 
   get upgraded() {
@@ -31,7 +97,27 @@ export default class Building {
     return this.new(this.level, speed);
   }
 
+  get disabled() {
+    return this.at(0);
+  }
+
+  prosumes(stock: Stock<ResourceType>): Prosumer<ResourceType> {
+    // TODO maybe we really don't need the lookups here, or can this work without the typecasts?
+    const prosumption = (this.prosumption[this.type] || {}) as ProsumptionEntries<ResourceType>;
+    const processes = Object.keys(prosumption).map((type) => {
+      const prosumptionFunc = prosumption[type as ResourceType] as LevelToProsumptionFunc; // never undefined
+      const rate = prosumptionFunc(this.level);
+      const stocked = stock.has(type as ResourceType);
+      // limit production for an optionally maximal stock
+      // also for energy a zero resource resource can be created implicitly
+      const max = stock.max.getByType(type as ResourceType) as Resource<ResourceType> || stocked;
+      return new ResourceProcess(rate > 0 ? max : stocked, rate);
+    });
+
+    return new Prosumer(this.type, ResourceProcessCollection.fromArray(processes), this.speed);
+  }
+
   toString() {
-    return `Building(${this.type}, ${this.level}, ${this.speed})`;
+    return `Building(${this.type}, ${this.level}, ${this.speed}%)`;
   }
 }

--- a/src/BuildingRequirement.spec.ts
+++ b/src/BuildingRequirement.spec.ts
@@ -4,7 +4,7 @@ import examples, { Types } from "./resources/examples";
 import BuildingRequirement from "./BuildingRequirement";
 import ResourceCollection from "./resources/ResourceCollection";
 import Stock from "./resources/Stock";
-import Factory from "./Factory";
+import Economy from "./Economy";
 
 describe("BuildingRequirement", () => {
   it("should be console printable", () => {
@@ -20,7 +20,7 @@ describe("BuildingRequirement", () => {
     const { t3, s3 } = examples;
     const ress = ResourceCollection.fromArray([t3, s3]);
     const stock = new Stock<Types>(ResourceCollection.fromArray([t3, s3]));
-    const factory = new Factory("Fact2", stock);
+    const factory = new Economy("Fact2", stock);
     const type = "B";
     const level = 1;
     const b = new BuildingRequirement(type, ress, 1, []);
@@ -37,7 +37,7 @@ describe("BuildingRequirement", () => {
     const { t0, t3, s3 } = examples;
     const ress = ResourceCollection.fromArray([t3, s3]);
     const stock0 = new Stock<Types>(ResourceCollection.fromArray([t0, s3]));
-    const factory = new Factory("Fact3", stock0);
+    const factory = new Economy("Fact3", stock0);
     const level = 1;
     const b = new BuildingRequirement("B", ress, 2, []);
 

--- a/src/BuildingRequirement.spec.ts
+++ b/src/BuildingRequirement.spec.ts
@@ -4,15 +4,15 @@ import examples, { Types } from "./resources/examples";
 import BuildingRequirement from "./BuildingRequirement";
 import ResourceCollection from "./resources/ResourceCollection";
 import Stock from "./resources/Stock";
-import Empire from "./Empire";
+import Factory from "./Factory";
 
 describe("BuildingRequirement", () => {
   it("should be console printable", () => {
     const { t3, s3 } = examples;
     const ress = ResourceCollection.fromArray([t3, s3]);
-    const stock = new Stock<Types>(ResourceCollection.fromArray([t3, s3]));
-    const empire = new Empire("Empire", stock);
-    const b = new BuildingRequirement("B", ress, empire);
+    // const stock = new Stock<Types>(ResourceCollection.fromArray([t3, s3]));
+    // const factory = new Factory("Fact1", stock);
+    const b = new BuildingRequirement("B", ress, 1.5, []);
     expect(b.toString()).to.eql("BuildingRequirement(B)");
   });
 
@@ -20,26 +20,28 @@ describe("BuildingRequirement", () => {
     const { t3, s3 } = examples;
     const ress = ResourceCollection.fromArray([t3, s3]);
     const stock = new Stock<Types>(ResourceCollection.fromArray([t3, s3]));
-    const empire = new Empire("Empire", stock);
+    const factory = new Factory("Fact2", stock);
     const type = "B";
-    const b = new BuildingRequirement(type, ress, empire);
+    const level = 1;
+    const b = new BuildingRequirement(type, ress, 1, []);
 
     expect(b.toString()).to.eql("BuildingRequirement(B)");
     expect(b.matches(type)).to.eql(true);
-    expect(b.satisfied).to.eql(true);
-    expect(b.satisfiedForDowngrade).to.eql(true);
-    expect(b.upgradeCost.toString()).to.eql("ResourceCollection[3tumbles, 3salties]");
-    expect(b.downgradeCost.toString()).to.eql("ResourceCollection[1tumbles, 1salties]");
+    expect(b.isSatisfied(level, factory.resources)).to.eql(true);
+    expect(b.isSatisfiedForDowngrade(level, factory.resources)).to.eql(true);
+    expect(b.getUpgradeCost(level).toString()).to.eql("ResourceCollection[3tumbles, 3salties]");
+    expect(b.getDowngradeCost(level).toString()).to.eql("ResourceCollection[1tumbles, 1salties]");
   });
 
   it("should not have enough resources", () => {
     const { t0, t3, s3 } = examples;
     const ress = ResourceCollection.fromArray([t3, s3]);
     const stock0 = new Stock<Types>(ResourceCollection.fromArray([t0, s3]));
-    const empire = new Empire("Empire", stock0);
-    const b = new BuildingRequirement("B", ress, empire);
+    const factory = new Factory("Fact3", stock0);
+    const level = 1;
+    const b = new BuildingRequirement("B", ress, 2, []);
 
     expect(b.toString()).to.eql("BuildingRequirement(B)");
-    expect(b.satisfied).to.eql(false);
+    expect(b.isSatisfied(level, factory.resources)).to.eql(false);
   });
 });

--- a/src/Economy.spec.ts
+++ b/src/Economy.spec.ts
@@ -42,7 +42,17 @@ describe("Factory Entity", () => {
       + "]",
     );
     expect(factory.resources.validFor).to.be.eql(Infinity);
-    // TODO a factory with default buildings
+    // TODO! a factory with minimal default buildings
+    // TODO storage limits 22, 23, 24
+    // TODO buildings for build speed upgrades 14, 15
+    // TODO building space and expansion 33
+    // TODO lab 31
+    // TODO And/Or (Building|Tech)Requirement
+    // TODO hangar 21 able to produce other units like ships 202, 203 with cargo capacity
+    // and misc
+    // TODO tech lab requirement 113 <= 31L1
+    // TODO tech for build requirements energy 12 <= 3L5, 113L3
+    // TODO lab network for tech speed up and tech share (with outsourcing cost)?
   });
 
   it("can upgrade buildings, in time", () => {

--- a/src/Empire.spec.ts
+++ b/src/Empire.spec.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import examples, { Types } from "./resources/examples";
 import ResourceCollection from "./resources/ResourceCollection";
 import Stock from "./resources/Stock";
-import Building from "./Building";
+import Building, { BuildingIdentifier } from "./Building";
 import Empire from "./Empire";
 
 describe("Empire Entity", () => {
@@ -16,7 +16,7 @@ describe("Empire Entity", () => {
 
   it("should have resources and buildings", () => {
     const { t3, s3 } = examples;
-    const buildings: Building[] = [];
+    const buildings: Building<BuildingIdentifier, Types>[] = [];
     const stock = new Stock<Types>(ResourceCollection.fromArray([t3, s3]));
     const empire = new Empire("AllFresh", stock, buildings);
     expect(empire.toString()).to.eql("AllFresh (Stock[3tumbles(0, Infinity), 3salties(0, Infinity)]) []");

--- a/src/Empire.ts
+++ b/src/Empire.ts
@@ -16,14 +16,6 @@ export default class Empire<BuildingType extends BuildingIdentifier, ResourceTyp
     this.name = name;
     this.buildings = buildings;
     this.resources = resources;
-    /* TODO factory to create resource processes from buildings
-    const prosumers = buildings.map((building) => {
-      return building.consumes();
-    });
-    const producers = buildings.map((building) => {
-      return building.produces();
-    });
-    */
   }
 
   toString() {

--- a/src/Empire.ts
+++ b/src/Empire.ts
@@ -1,18 +1,29 @@
-import { ResourceIdentifier } from "./resources/Resource";
-import Building from "./Building";
-import Stock from "./resources/Stock";
 
-export default class Empire<Types extends ResourceIdentifier> {
+import type { ResourceIdentifier } from "./resources";
+import { Stock } from "./resources";
+import Building, { BuildingIdentifier } from "./Building";
+
+export default class Empire<BuildingType extends BuildingIdentifier, ResourceTypes extends ResourceIdentifier> {
   name = "";
 
-  buildings: Building[] = [];
+  buildings: Building<BuildingType, ResourceTypes>[] = [];
 
-  resources: Stock<Types>;
+  resources: Stock<ResourceTypes>;
 
-  constructor(name: string, resources: Stock<Types>, buildings: Building[] = []) {
+  // energy: EnergyCalculation<Types>;
+
+  constructor(name: string, resources: Stock<ResourceTypes>, buildings: Building<BuildingType, ResourceTypes>[] = []) {
     this.name = name;
     this.buildings = buildings;
     this.resources = resources;
+    /* TODO factory to create resource processes from buildings
+    const prosumers = buildings.map((building) => {
+      return building.consumes();
+    });
+    const producers = buildings.map((building) => {
+      return building.produces();
+    });
+    */
   }
 
   toString() {

--- a/src/Factory.spec.ts
+++ b/src/Factory.spec.ts
@@ -1,0 +1,286 @@
+import { expect } from "chai";
+
+import { stock, buildings, overconsumingBuildings, underBlubberBuildings, ResourceTypes } from "./examples";
+import Factory from "./Factory";
+import { ResourceCollection, ResourceProcess, Stock } from "./resources";
+import { TumbleResource, BlubbResource, SaltyResource } from "./resources/examples";
+
+describe("Factory Entity", () => {
+  it("should be console printable", () => {
+    const factory = new Factory("Console", stock, [buildings[0], buildings[2]]);
+    const empty = new Factory("Empty", stock, []);
+    expect(empty.toString()).to.eql("Empty (Processing energy&resources: ) []");
+    expect(factory.toString()).to.eql(
+      "Console (Processing energy&resources: "
+      + "50/50 energy, 0/0 heat, "
+      + "3tumbles(0, Infinity): 0, "
+      + "3salties(0, Infinity): 0, "
+      + "15blubbs(0, Infinity): -10"
+      + ") ["
+      + "Building(12, 1, 100%), "
+      + "Building(0, 1, 50%)"
+      + "]",
+    );
+    expect(factory.stock.toString()).to.eql(
+      "Stock[3tumbles(0, Infinity), 3salties(0, Infinity), 15blubbs(0, Infinity)]",
+    );
+  });
+
+  it("should have resources and buildings", () => {
+    const factory = new Factory("Factory", stock, buildings);
+    expect(factory.toString()).to.eql(
+      "Factory (Processing energy&resources: "
+      + "30/50 energy, 0/0 heat, "
+      + "3salties(0, Infinity): +20, "
+      // + "15blubbs(0, Infinity): -10+10
+      + "15blubbs(0, Infinity): 0, "
+      + "3tumbles(0, Infinity): 0" // TODO? fix ordering for zero (missing) resource production
+      + ") ["
+      + "Building(12, 1, 100%), "
+      + "Building(3, 1, 100%), "
+      + "Building(0, 1, 50%), "
+      + "Building(2, 1, 100%)"
+      + "]",
+    );
+    expect(factory.resources.validFor).to.be.eql(Infinity);
+    // TODO a factory with default buildings
+  });
+
+  it("can upgrade buildings, in time", () => {
+    const factory = new Factory("Factory", stock, buildings);
+    // TODO check substracted resources
+    // TODO check build time
+    expect(factory.upgrade(factory.buildings[0].type).toString()).to.eql(
+      "Factory (Processing energy&resources: "
+      + "194/214 energy, 0/0 heat, "
+      + "3salties(0, Infinity): +20, "
+      + "15blubbs(0, Infinity): -33, "
+      + "3tumbles(0, Infinity): 0"
+      + ") ["
+      + "Building(12, 2, 100%), "
+      + "Building(3, 1, 100%), "
+      + "Building(0, 1, 50%), "
+      + "Building(2, 1, 100%)"
+      + "]",
+    );
+    expect(factory.downgrade(factory.buildings[0].type).toString()).to.eql(
+      "Factory (Processing energy&resources: "
+      + "-20/0 energy, 0/0 heat, "
+      + "Degraded to 0%, "
+      + "3salties(0, Infinity): 0, "
+      + "15blubbs(0, Infinity): 0, "
+      + "3tumbles(0, Infinity): 0"
+      + ") ["
+      + "Building(12, 0, 100%), "
+      + "Building(3, 1, 100%), "
+      + "Building(0, 1, 50%), "
+      + "Building(2, 1, 100%)"
+      + "]",
+    );
+
+
+  });
+
+  it("should tick", () => {
+    // for now just exhaust resources for unused energy (doesn't accumulate)
+    const stock = new Stock<ResourceTypes>(ResourceCollection.fromArray([new BlubbResource(30)]));
+    const factory = new Factory("Tick", stock, [buildings[0], buildings[2]]);
+    expect(factory.toString()).to.eql(
+      "Tick (Processing energy&resources: "
+      + "50/50 energy, 0/0 heat, "
+      + "0tumbles(0, Infinity): 0, "
+      + "0salties(0, Infinity): 0, "
+      + "30blubbs(0, Infinity): -10"
+      + ") ["
+      + "Building(12, 1, 100%), "
+      + "Building(0, 1, 50%)"
+      + "]",
+    );
+    const ft1 = factory.tick();
+    expect(ft1.toString()).to.eql(
+      "Tick (Processing energy&resources: "
+      + "50/50 energy, 0/0 heat, "
+      + "0tumbles(0, Infinity): 0, "
+      + "0salties(0, Infinity): 0, "
+      + "20blubbs(0, Infinity): -10"
+      + ") ["
+      + "Building(12, 1, 100%), "
+      + "Building(0, 1, 50%)"
+      + "]",
+    );
+    const ft2 = ft1.tick();
+    expect(ft2.toString()).to.eql(
+      "Tick (Processing energy&resources: "
+      + "50/50 energy, 0/0 heat, "
+      + "0tumbles(0, Infinity): 0, "
+      + "0salties(0, Infinity): 0, "
+      + "10blubbs(0, Infinity): -10"
+      + ") ["
+      + "Building(12, 1, 100%), "
+      + "Building(0, 1, 50%)"
+      + "]",
+    );
+    expect(ft2.resources.validFor).to.be.eql(1);
+    const ft3 = ft2.tick();
+    expect(ft3.toString()).to.eql(
+      "Tick (Processing energy&resources: "
+      + "50/50 energy, 0/0 heat, "
+      + "0tumbles(0, Infinity): 0, "
+      + "0salties(0, Infinity): 0, "
+      + "0blubbs(0, Infinity): -10"
+      + ") ["
+      + "Building(12, 1, 100%), "
+      + "Building(0, 1, 50%)"
+      + "]",
+    );
+    expect(ft3.resources.validFor).to.be.eql(0);
+    // without a recalculation strategy this would bug out
+    expect(() => {
+      const ft3i = ft2.tick();
+      ft3i.recalculationStrategy = (_, bs) => bs;
+      const ft4i = ft3i.tick();
+      expect(ft4i.toString()).to.eql(
+        "Tick (Processing energy&resources: "
+        + "50/50 energy, 0/0 heat, "
+        + "0tumbles(0, Infinity): 0, "
+        + "0salties(0, Infinity): 0, "
+        + "0blubbs(0, Infinity): -10"
+        + ") ["
+        + "Building(12, 1, 100%), "
+        + "Building(0, 1, 50%)"
+        + "]",
+      );
+    }).to.throw("Invalid resource (re)calculation");
+
+    // now things are offline everything is fine
+    const ft4 = ft3.tick();
+    expect(ft4.toString()).to.eql(
+      "Tick (Processing energy&resources: "
+      + "0/0 energy, 0/0 heat, "
+      + "0tumbles(0, Infinity): 0, "
+      + "0salties(0, Infinity): 0, "
+      + "0blubbs(0, Infinity): 0"
+      + ") ["
+      + "Building(12, 1, 0%), "
+      + "Building(0, 1, 50%)"
+      + "]",
+    );
+    const ft5 = ft4.tick();
+    expect(ft5.toString()).to.eql(
+      "Tick (Processing energy&resources: "
+      + "0/0 energy, 0/0 heat, "
+      + "0tumbles(0, Infinity): 0, "
+      + "0salties(0, Infinity): 0, "
+      + "0blubbs(0, Infinity): 0"
+      + ") ["
+      + "Building(12, 1, 0%), "
+      + "Building(0, 1, 50%)"
+      + "]",
+    );
+    expect(ft5.resources.validFor).to.be.eql(Infinity);
+
+  });
+
+  // a) tumble plant (ID 1) is upgraded and now overconsumption slows everything, even more when blubber runs out
+  it("a series of ticks retriggering recalculations with different impacts", () => {
+    // first rates are already bad because e.g. recently upgraded building consumes more energy than solar provides
+    // then blubbs run out again, so the drop brings everything to a slow grind
+    const tumbles = new TumbleResource(10);
+    const blubbs = new BlubbResource(30);
+    const stock = new Stock<ResourceTypes>(ResourceCollection.fromArray([tumbles, new SaltyResource(0), blubbs]));
+    const factory = new Factory("Overtumbling", stock, overconsumingBuildings);
+    // full rate would be 129, but -13/50 energy degrades it
+    const tumbleProcess = new ResourceProcess(tumbles.infinite, 129 * (50/(13+50))**1.1 );
+    const blubbProcess = new ResourceProcess(blubbs.infinite, 8 - 10);
+    expect(factory.resources.resources.processes.getByType(tumbleProcess.type)).to.eql(tumbleProcess);
+    expect(factory.resources.resources.processes.getByType(blubbProcess.type)).to.eql(blubbProcess);
+    // under energy & even more under energy after blubber drop
+    expect(factory.resources.productionTable).to.eql([
+      "-13/50 energy",
+      "0/0 heat",
+      "Degraded to 78%", //
+      "10tumbles(0, Infinity): +100", // degraded from 129
+      "0salties(0, Infinity): +16", // degraded from 20
+      "30blubbs(0, Infinity): -2", // degraded from 0 (10-10)
+    ]);
+    expect(factory.toString()).to.eql(
+      "Overtumbling (Processing energy&resources: "
+      + "-13/50 energy, 0/0 heat, "
+      + "Degraded to 78%, "
+      + "10tumbles(0, Infinity): +100, " // degraded from 129
+      + "0salties(0, Infinity): +16, " // degraded from 20
+      + "30blubbs(0, Infinity): -2"
+      + ") ["
+      + "Building(12, 1, 100%), "
+      + "Building(1, 2, 100%), " // just upgraded
+      + "Building(2, 1, 100%), "
+      + "Building(3, 1, 100%), "
+      + "Building(0, 1, 50%)"
+      + "]",
+    );
+    expect(factory.resources.validFor).to.be.eql(15);
+    const f15 = factory.tick(15);
+    expect(f15.resources.productionTable).to.eql([
+      "-13/50 energy",
+      "0/0 heat",
+      "Degraded to 78%", //
+      "1510tumbles(0, Infinity): +100",
+      "240salties(0, Infinity): +16",
+      "0blubbs(0, Infinity): -2",
+    ]);
+    expect(f15.resources.validFor).to.be.eql(0);
+    const ff = f15.tick();
+    expect(ff.resources.productionTable).to.eql([
+      "0/0 energy",
+      "0/0 heat",
+      // "Degraded to 0%",
+      "1510tumbles(0, Infinity): 0",
+      "240salties(0, Infinity): 0",
+      "0blubbs(0, Infinity): 0",
+    ]);
+    expect(ff.resources.validFor).to.be.eql(Infinity);
+  });
+
+  // b) blubber power (ID 12) is upgraded to more consumption than the production plant (ID 3) offers with empty buffers
+  it("should cover the rare blubber underflow", () => {
+    // this feels a bit redundant with the test above, but it should be more common
+    const stock = new Stock<ResourceTypes>(ResourceCollection.fromArray([new TumbleResource(10), new SaltyResource(0), new BlubbResource(40)]));
+    const factory = new Factory("Underblubbling", stock, underBlubberBuildings);
+    expect(factory.resources.productionTable).to.eql([
+      "171/234 energy",
+      "0/0 heat",
+      "40blubbs(0, Infinity): -33",
+      "10tumbles(0, Infinity): +129",
+      "0salties(0, Infinity): +20",
+    ]);
+    expect(factory.resources.validFor).to.be.eql(1);
+    const f2 = factory.tick(2);
+    expect(f2.resources.productionTable).to.eql([
+      "-43/20 energy",
+      "0/0 heat",
+      "Degraded to 28%",
+      // TODO fix ordering, always tumble mine first?
+      "10blubbs(0, Infinity): +3", // degraded
+      "176tumbles(0, Infinity): +37", // degraded
+      "26salties(0, Infinity): +6", // degraded
+    ]);
+    expect(f2.toString()).to.eql(
+      "Underblubbling (Processing energy&resources: "
+      + "-43/20 energy, 0/0 heat, "
+      + "Degraded to 28%, "
+      + "10blubbs(0, Infinity): +3, "
+      + "176tumbles(0, Infinity): +37, "
+      + "26salties(0, Infinity): +6"
+      //+ "26salties(0, Infinity): +6, "
+      //+ "10blubbs(0, Infinity): +3"
+      + ") ["
+      + "Building(12, 2, 0%), "
+      + "Building(1, 2, 100%), " // just upgraded
+      + "Building(2, 1, 100%), "
+      + "Building(3, 1, 100%), "
+      + "Building(0, 1, 50%), "
+      + "Building(4, 1, 100%)"
+      + "]",
+    );
+  });
+});

--- a/src/Factory.spec.ts
+++ b/src/Factory.spec.ts
@@ -195,7 +195,7 @@ describe("Factory Entity", () => {
     expect(factory.resources.resources.processes.getByType(tumbleProcess.type)).to.eql(tumbleProcess);
     expect(factory.resources.resources.processes.getByType(blubbProcess.type)).to.eql(blubbProcess);
     // under energy & even more under energy after blubber drop
-    expect(factory.resources.productionTable).to.eql([
+    expect(factory.resources.productionEntries).to.eql([
       "-13/50 energy",
       "0/0 heat",
       "Degraded to 78%", //
@@ -220,7 +220,7 @@ describe("Factory Entity", () => {
     );
     expect(factory.resources.validFor).to.be.eql(15);
     const f15 = factory.tick(15);
-    expect(f15.resources.productionTable).to.eql([
+    expect(f15.resources.productionEntries).to.eql([
       "-13/50 energy",
       "0/0 heat",
       "Degraded to 78%", //
@@ -230,7 +230,7 @@ describe("Factory Entity", () => {
     ]);
     expect(f15.resources.validFor).to.be.eql(0);
     const ff = f15.tick();
-    expect(ff.resources.productionTable).to.eql([
+    expect(ff.resources.productionEntries).to.eql([
       "0/0 energy",
       "0/0 heat",
       // "Degraded to 0%",
@@ -246,7 +246,7 @@ describe("Factory Entity", () => {
     // this feels a bit redundant with the test above, but it should be more common
     const stock = new Stock<ResourceTypes>(ResourceCollection.fromArray([new TumbleResource(10), new SaltyResource(0), new BlubbResource(40)]));
     const factory = new Factory("Underblubbling", stock, underBlubberBuildings);
-    expect(factory.resources.productionTable).to.eql([
+    expect(factory.resources.productionEntries).to.eql([
       "171/234 energy",
       "0/0 heat",
       "40blubbs(0, Infinity): -33",
@@ -255,7 +255,7 @@ describe("Factory Entity", () => {
     ]);
     expect(factory.resources.validFor).to.be.eql(1);
     const f2 = factory.tick(2);
-    expect(f2.resources.productionTable).to.eql([
+    expect(f2.resources.productionEntries).to.eql([
       "-43/20 energy",
       "0/0 heat",
       "Degraded to 28%",

--- a/src/Factory.ts
+++ b/src/Factory.ts
@@ -1,0 +1,103 @@
+import type { ResourceIdentifier } from "./resources";
+import { EnergyCalculation, Stock } from "./resources";
+import Building, { BuildingIdentifier } from "./Building";
+import ProsumerCollection from "./resources/ProsumerCollection";
+
+/**
+ * Factory has its own resource and energy mangement,
+ * could even model a whole planet
+ */
+export default class Factory<BuildingType extends BuildingIdentifier, ResourceTypes extends ResourceIdentifier> {
+
+  readonly name: string;
+
+  readonly buildings: Building<BuildingType, ResourceTypes>[] = [];
+
+  readonly resources: EnergyCalculation<ResourceTypes>;
+
+  constructor(name: string, resources: Stock<ResourceTypes>, buildings: Building<BuildingType, ResourceTypes>[] = []) {
+    this.name = name;
+    this.buildings = buildings;
+
+    this.resources = this.getResourceCalculation(resources, buildings);
+  }
+
+  get stock() {
+    return this.resources.stock;
+  }
+
+  getResourceCalculation(resources: Stock<ResourceTypes>, buildings: Building<BuildingType, ResourceTypes>[]) {
+    const prosumers = new ProsumerCollection(buildings.map((building) => {
+      return building.prosumes(resources);
+    }));
+    return EnergyCalculation.newStock<ResourceTypes>(resources, prosumers);
+  }
+
+  protected new(resources: Stock<ResourceTypes>, buildings: Building<BuildingType, ResourceTypes>[]) {
+    return new Factory(this.name, resources, buildings);
+  }
+
+  /**
+   * Adjust consumption of exhausted resources
+   */
+  recalculationStrategy(stock: Stock<ResourceTypes>, buildings: Building<BuildingType, ResourceTypes>[]): Building<BuildingType, ResourceTypes>[] {
+    const prosumers = new ProsumerCollection<ResourceTypes>(buildings.map((b) => b.prosumes(stock)));
+    const nextTickWithdrawal = prosumers.reduced.getNegativeResourcesFor(1);
+    if (!stock.isFetchable(nextTickWithdrawal)) {
+      const missing = stock.getUnfetchable(nextTickWithdrawal);
+      return buildings.map((building) => {
+        const halt = missing.asArray.some((resource) => building.prosumes(stock).consumes(resource));
+        if (halt) {
+          // halt building production if its prosumption includes consumption which can't be fulfilled
+          return building.disabled;
+        }
+        return building;
+      });
+    }
+    return buildings.map((building) => {
+      // const prosumer = building.prosumes(resources);
+      // if (prosumer.consumes())
+      // console.log("disabling building", building.toString(), prosumer.toString());
+      return building.disabled;
+    });
+  }
+
+  upgrade(buildingType: BuildingIdentifier) {
+    return this.new(this.resources.stock, this.buildings.map((building: Building<BuildingType, ResourceTypes>) => {
+      if (building.type === buildingType) {
+        return building.upgraded;
+      }
+      return building;
+    }));
+  }
+
+  downgrade(buildingType: BuildingIdentifier) {
+    return this.new(this.resources.stock, this.buildings.map((building: Building<BuildingType, ResourceTypes>) => {
+      if (building.type === buildingType) {
+        return building.downgraded;
+      }
+      return building;
+    }));
+  }
+
+  tick(cycles = 1) {
+    let { resources, buildings } = this;
+    while (resources.validFor < cycles) {
+      const advanceCycles = resources.validFor;
+      cycles -= advanceCycles;
+      resources = resources.calculate(advanceCycles);
+      buildings = this.recalculationStrategy(resources.stock, buildings);
+      resources = this.getResourceCalculation(resources.stock, buildings);
+      if (!resources.validFor) {
+        throw new Error("Invalid resource (re)calculation");
+      }
+    }
+
+    resources = resources.calculate(cycles);
+    return this.new(resources.stock, buildings);
+  }
+
+  toString() {
+    return `${this.name} (${this.resources}) [${this.buildings.join(", ")}]`;
+  }
+}

--- a/src/FactoryEnvironment.spec.ts
+++ b/src/FactoryEnvironment.spec.ts
@@ -1,0 +1,24 @@
+import { expect } from "chai";
+
+import examples, { Types } from "./resources/examples";
+import ResourceCollection from "./resources/ResourceCollection";
+import Stock from "./resources/Stock";
+import FactoryEnvironment from "./FactoryEnvironment";
+
+describe("FactoryEnvironment Entity", () => {
+  it("should be console printable", () => {
+    const { t3, s3 } = examples;
+    const stock = new Stock<Types>(ResourceCollection.fromArray([t3, s3]));
+    const empire = new FactoryEnvironment("FactoryEnvironment", stock);
+    expect(empire.toString()).to.eql("FactoryEnvironment (Stock[3tumbles(0, Infinity), 3salties(0, Infinity)])");
+  });
+
+  it("should have resources to mine from", () => {
+    const { t3, s3 } = examples;
+    const stock = new Stock<Types>(ResourceCollection.fromArray([t3, s3]));
+    const empire = new FactoryEnvironment("Planet", stock);
+    expect(empire.toString()).to.eql("Planet (Stock[3tumbles(0, Infinity), 3salties(0, Infinity)])");
+  });
+
+  // it.todo("should have properties - e.g. base temperature to start from");
+});

--- a/src/FactoryEnvironment.ts
+++ b/src/FactoryEnvironment.ts
@@ -1,0 +1,18 @@
+
+import type { ResourceIdentifier } from "./resources";
+import { Stock } from "./resources";
+
+export default class FactoryEnvironment<Types extends ResourceIdentifier> {
+  name = "";
+  resources: Stock<Types>;
+  // TODO add other properties, as a map?
+
+  constructor(name: string, resources: Stock<Types>) {
+    this.name = name;
+    this.resources = resources;
+  }
+
+  toString() {
+    return `${this.name} (${this.resources})`;
+  }
+}

--- a/src/examples.ts
+++ b/src/examples.ts
@@ -1,0 +1,188 @@
+import examples, { ResourceTypes, EnergyTypes, TumbleResource, SaltyResource, BlubbResource } from "./resources/examples";
+export type ResourceLike = ResourceTypes | EnergyTypes;
+export type { ResourceTypes, EnergyTypes } from "./resources/examples";
+import { Stock, ResourceCollection } from "./resources";
+import Empire from "./Empire";
+import Building, { BuildingIdentifier, ProsumptionLookup, RequirementLookup } from "./Building";
+import BuildingRequirement from "./BuildingRequirement";
+
+export const requirements: RequirementLookup<BuildingIdentifier, ResourceLike> = {
+  // tumble mine
+  1: new BuildingRequirement<BuildingIdentifier, ResourceLike>(1,
+    ResourceCollection.fromArray<ResourceLike>([
+      new TumbleResource(60),
+      new SaltyResource(15),
+    ]),
+    1.5,
+    [],
+  ),
+  // salty mine
+  2: new BuildingRequirement<BuildingIdentifier, ResourceLike>(2,
+    ResourceCollection.fromArray<ResourceLike>([
+      new TumbleResource(48),
+      new SaltyResource(24),
+    ]),
+    1.6,
+    [],
+  ),
+  // blubber mine
+  3: new BuildingRequirement<BuildingIdentifier, ResourceLike>(3,
+    ResourceCollection.fromArray<ResourceLike>([
+      new TumbleResource(225),
+      new SaltyResource(75),
+    ]),
+    1.5,
+    [],
+  ),
+  // power
+  4: new BuildingRequirement<BuildingIdentifier, ResourceLike>(4,
+    ResourceCollection.fromArray<ResourceLike>([
+      new TumbleResource(75),
+      new SaltyResource(30),
+    ]),
+    1.5,
+    [],
+  ),
+  // power based on blubber
+  12: new BuildingRequirement<BuildingIdentifier, ResourceLike>(12,
+    ResourceCollection.fromArray<ResourceLike>([
+      new TumbleResource(48),
+      new SaltyResource(24),
+    ]),
+    1.8,
+    [
+      {
+        type: 3,
+        level: 5,
+      },
+      {
+        type: 113,
+        level: 3,
+      },
+    ],
+  ),
+  // build buildings faster! TODO we need to add the time reducing factors
+  14: new BuildingRequirement<BuildingIdentifier, ResourceLike>(14, // robots factor=1/(1+level)
+    ResourceCollection.fromArray<ResourceLike>([
+      new TumbleResource(400),
+      new SaltyResource(120),
+      new BlubbResource(200),
+    ]),
+    2,
+    [],
+  ), // FASTER
+  15: new BuildingRequirement<BuildingIdentifier, ResourceLike>(15, // nanites factor=1/2^level
+    ResourceCollection.fromArray<ResourceLike>([
+      new TumbleResource(1000000),
+      new SaltyResource(500000),
+      new BlubbResource(100000),
+    ]),
+    2,
+    [
+      {
+        type: 14,
+        level: 10,
+      },
+      {
+        type: 108,
+        level: 10,
+      },
+    ],
+  ),
+  // lab
+  31: new BuildingRequirement<BuildingIdentifier, ResourceLike>(31,
+    ResourceCollection.fromArray<ResourceLike>([
+      new TumbleResource(200),
+      new SaltyResource(400),
+      new BlubbResource(200),
+    ]),
+    2,
+    [],
+  ),
+  // tech (above 100)
+  109: new BuildingRequirement<BuildingIdentifier, ResourceLike>(113, // computer
+    ResourceCollection.fromArray<ResourceLike>([
+      new SaltyResource(800),
+      new BlubbResource(400),
+    ]),
+    2,
+    [
+      {
+        type: 31,
+        level: 4,
+      },
+    ],
+  ),
+  113: new BuildingRequirement<BuildingIdentifier, ResourceLike>(113, // energy
+    ResourceCollection.fromArray<ResourceLike>([
+      new SaltyResource(800),
+      new BlubbResource(400),
+    ]),
+    2,
+    [
+      {
+        type: 31,
+        level: 1,
+      },
+    ],
+  ),
+  // TODO add the remaining buildings and tech aswell as fleet (with ids above 200)
+};
+export const prosumption: ProsumptionLookup<BuildingIdentifier, ResourceLike> = {
+  0: {
+    [ResourceTypes.Tumble]: () => { return 0; },
+    [ResourceTypes.Salty]: () => { return 0; },
+    [ResourceTypes.Blubber]: () => { return 0; },
+    [EnergyTypes.Electricity]: () => { return 0; },
+    [EnergyTypes.Heat]: () => { return 0; },
+  },
+  1: {
+    [ResourceTypes.Tumble]: (lvl: number) => 30 * lvl * lvl ** 1.1,
+    [EnergyTypes.Electricity]: (lvl: number) => - 10 * lvl * lvl ** 1.1,
+  },
+  2: {
+    [ResourceTypes.Salty]: (lvl: number) => 20 * lvl * lvl ** 1.1,
+    [EnergyTypes.Electricity]: (lvl: number) => - 10 * lvl * lvl ** 1.1,
+  },
+  3: {
+    // TODO actually [ResourceTypes.Blubber]: (lvl, planet) => 10 * lvl * lvl ** 1.1 * (-0.002 * planet.maxTemperature + 1.28),
+    [ResourceTypes.Blubber]: (lvl: number) => {
+      return 10 * lvl * lvl ** 1.1;
+    },
+    [EnergyTypes.Electricity]: (lvl: number) => {
+      return -10 * lvl * lvl ** 1.1;
+    },
+  },
+  4: {
+    [EnergyTypes.Electricity]: (lvl: number) => 20 * lvl * lvl ** 1.1,
+  },
+  12: {
+    [ResourceTypes.Blubber]: (lvl: number) => {
+      return -10 * lvl * lvl ** 1.1;
+    },
+    [EnergyTypes.Electricity]: (lvl: number) => {
+      return 50 * lvl * lvl ** 1.1;
+    },
+  },
+};
+const b = new Building<BuildingIdentifier, ResourceLike>(12, requirements, prosumption, 1, 100);
+const bUpgraded = new Building<BuildingIdentifier, ResourceLike>(12, requirements, prosumption, 2, 100);
+const b0 = new Building<BuildingIdentifier, ResourceLike>(0, requirements, prosumption, 1, 50); // 0 times 0,5 is still 0
+const b3 = new Building<BuildingIdentifier, ResourceLike>(3, requirements, prosumption, 1, 100);
+const b1 = new Building<BuildingIdentifier, ResourceLike>(1, requirements, prosumption, 2, 100);
+const b2 = new Building<BuildingIdentifier, ResourceLike>(2, requirements, prosumption, 1, 100);
+const b4 = new Building<BuildingIdentifier, ResourceLike>(4, requirements, prosumption, 1, 100);
+export const buildings: Building<BuildingIdentifier, ResourceLike>[] = [b, b3, b0, b2];
+export const overconsumingBuildings: Building<BuildingIdentifier, ResourceLike>[] = [b, b1, b2, b3, b0];
+export const underBlubberBuildings: Building<BuildingIdentifier, ResourceLike>[] = [bUpgraded, b1, b2, b3, b0, b4];
+export const defaultBuildings: Building<BuildingIdentifier, ResourceLike>[] = [b1.downgraded, b2, b4];
+const { t3, s3, b15 } = examples;
+export const resourceCollection = ResourceCollection.fromArray<ResourceTypes>([t3, s3, b15]);
+export const emptyResourceCollection = ResourceCollection.fromArray<ResourceTypes>([t3.zero, s3.zero, b15.zero]);
+export const stock = new Stock<ResourceTypes>(resourceCollection);
+export const emptyStock = new Stock<ResourceTypes>(emptyResourceCollection);
+
+
+const empire = new Empire("Phlameland", stock, buildings);
+
+export default empire;

--- a/src/resources/Energy.spec.ts
+++ b/src/resources/Energy.spec.ts
@@ -1,0 +1,61 @@
+import { expect } from "chai";
+
+import { energy, EnergyResource, EnergyTypes } from "./examples";
+
+describe("Energy Resource ValueObject", () => {
+  it("should be console printable", () => {
+    const { e0 } = energy;
+    expect(e0.toString()).to.eql(`Energy[0${EnergyTypes.Electricity}]`);
+  });
+
+  it("is int32 and immutable, very similar to a Resource but never infinite", () => {
+    const { e0, e10 } = energy;
+
+    expect(e0.add(e10)).to.be.eql(e10);
+    expect(e10.subtract(e0)).to.be.eql(e10);
+    expect(e10.infinite.times(3)).to.be.eql(e10.zero);
+  });
+
+  it("should compare energy amounts", () => {
+    const {
+      em10, e0, e10,
+      h0,
+    } = energy;
+    const e10a = new EnergyResource(10);
+    expect(e10.equals(e10a)).to.be.true;
+    expect(e0.equals(e10)).to.be.false;
+
+    expect(e0.equals(h0)).to.be.false;
+
+    expect(() => {
+      e10.isMoreOrEquals(h0);
+    }).to.throw(TypeError);
+    expect(() => {
+      e0.isLessOrEquals(h0);
+    }).to.throw(TypeError);
+
+    expect(e0.isLessOrEquals(e10)).to.be.true;
+    expect(em10.isLessOrEquals(e10)).to.be.true;
+    expect(e10.isMoreOrEquals(e0)).to.be.true;
+  });
+
+  it("should add and subtract energy amounts", () => {
+    const {
+      em10, e0, e10,
+      h0, h10,
+    } = energy;
+    expect(e0.add(e10)).to.be.eql(e10);
+    expect(e0.infinite.add(e10)).to.be.eql(e0.infinite);
+    expect(e0.add(e0.infinite)).to.be.eql(e0.infinite);
+    expect(e0.addAmount(10)).to.be.eql(e10);
+    expect(e10.subtract(e0)).to.be.eql(e10);
+    expect(e0.subtract(e10)).to.be.eql(em10);
+
+    expect(() => {
+      e0.add(h10);
+    }).to.throw(TypeError);
+    expect(() => {
+      e0.subtract(h0);
+    }).to.throw(TypeError);
+  });
+});

--- a/src/resources/Energy.ts
+++ b/src/resources/Energy.ts
@@ -1,0 +1,119 @@
+import {
+  ResourceIdentifier,
+  BaseResources,
+  ResourceValue,
+  ComparableResource,
+} from "./Resource";
+
+const MAX_VALUE = Number.POSITIVE_INFINITY; // if we want Number.MAX_VALUE here instead we need more checks getting closer to it
+
+// TODO wouldn't typing be easier/nicer with energy inheriting from Resource? do we even need this file, it duplicates Resource?
+export default class Energy<Type extends ResourceIdentifier = BaseResources.Energy>
+implements ResourceValue<Type>, ComparableResource<Type> {
+  static types: ResourceIdentifier[] = [BaseResources.Null];
+
+  static MAX_VALUE = MAX_VALUE;
+
+  readonly type: Type;
+
+  readonly amount: number; // int32
+
+  constructor(type: Type, amount: number) {
+    this.amount = amount | 0; // int32|0 handling is very fast in v8 - cutting off the floating part of the number
+    this.type = type;
+  }
+
+  get prettyAmount(): string {
+    return `${this.amount}${this.type}`;
+  }
+
+  /**
+   * Create another resource of the same type
+   */
+  protected new(amount: number) {
+    return new Energy(this.type, amount);
+  }
+
+  get isEnergy() {
+    return !!~Energy.types.indexOf(this.type);
+  }
+
+  get zero(): Energy<Type> {
+    return this.new(0);
+  }
+
+  get infinite(): Energy<Type> {
+    // copy, and bypass int32|0 parsing (would be Infinity|0 = 0)
+    const inf = Object.create(this);
+    inf.type = this.type;
+    inf.amount = Energy.MAX_VALUE;
+    return inf;
+  }
+
+  protected checkInfinity(energy?: Energy<Type>): Energy<Type> | false {
+    // Need to check for Infinity explicitly, as it's cheated around the constructor
+    // which would cast it to in32, result: 0
+    if (this.amount === Energy.MAX_VALUE) {
+      return this;
+    }
+    if (energy && energy?.amount === Energy.MAX_VALUE) {
+      return energy;
+    }
+    return false;
+  }
+
+  equalOfTypeTo(energy: ResourceValue<Type>) {
+    return energy.type === this.type;
+  }
+
+  equals(energy: Energy<Type>): boolean {
+    return this.equalOfTypeTo(energy)
+      // Usually we would need an epsilon to do a float comparison, but since we casted to int32, this works
+      && energy.amount === this.amount;
+  }
+
+  isMoreOrEquals(energy: Energy<Type>): boolean {
+    if (!this.equalOfTypeTo(energy)) {
+      throw new TypeError(`Energy types don't match (${this.type} != ${energy.type})`);
+    }
+    return this.amount >= energy.amount;
+  }
+
+  isLessOrEquals(energy: Energy<Type>): boolean {
+    if (!this.equalOfTypeTo(energy)) {
+      throw new TypeError(`Energy types don't match (${this.type} != ${energy.type})`);
+    }
+    return this.amount <= energy.amount;
+  }
+
+  add(resource: Energy<Type>) {
+    if (!this.equalOfTypeTo(resource)) {
+      throw new TypeError(`Energy types don't match (${this.type} != ${resource.type})`);
+    }
+    return this.checkInfinity(resource) || this.new(this.amount + resource.amount);
+  }
+
+  addAmount(amount: number) {
+    return this.checkInfinity() || this.new(this.amount + amount);
+  }
+
+  /**
+   * Substract another energy amount
+   * Available energy may be negative in contrast to resources
+   * @param subtrahend
+   */
+  subtract(subtrahend: Energy<Type>) {
+    if (!this.equalOfTypeTo(subtrahend)) {
+      throw new TypeError(`Energy types don't match (${this.type} != ${subtrahend.type})`);
+    }
+    return this.new(this.amount - subtrahend.amount);
+  }
+
+  times(factor: number): Energy<Type> {
+    return this.new(this.amount * factor);
+  }
+
+  toString() {
+    return `Energy[${this.prettyAmount}]`;
+  }
+}

--- a/src/resources/Energy.ts
+++ b/src/resources/Energy.ts
@@ -50,6 +50,10 @@ implements ResourceValue<Type>, ComparableResource<Type> {
     return inf;
   }
 
+  get isInfinite(): boolean {
+    return this.amount === Number.POSITIVE_INFINITY;
+  }
+
   protected checkInfinity(energy?: Energy<Type>): Energy<Type> | false {
     // Need to check for Infinity explicitly, as it's cheated around the constructor
     // which would cast it to in32, result: 0

--- a/src/resources/EnergyCalculation.spec.ts
+++ b/src/resources/EnergyCalculation.spec.ts
@@ -26,10 +26,15 @@ describe("EnergyCalculation (extended ResourceCalculation) ValueObject", () => {
     ]);
     const resourceCalculation = new ResourceCalculation(stock, resourceProcesses);
     const energyCalculation = new EnergyCalculation(resourceCalculation, prosumers);
-    expect(energyCalculation.productionTable).to.eql([
+    expect(energyCalculation.productionEntries).to.eql([
       "150/150 energy",
       "3tumbles(0, Infinity): +1",
       "3salties(0, Infinity): -1",
+    ]);
+    expect(energyCalculation.productionTable).to.eql([
+      ["energy", 150, 150],
+      ["tumbles", 1, 3, 0, Infinity],
+      ["salties", -1, 3, 0, Infinity],
     ]);
     expect(energyCalculation.prettyProsumers).to.eql([
       "Prosumer(EnergyProducer, 100%, ResourceProcessCollection[0energy+50])", "Prosumer(EnergyProducer, 100%, ResourceProcessCollection[0energy+50])", "Prosumer(EnergyProducer, 100%, ResourceProcessCollection[0energy+50])",

--- a/src/resources/EnergyCalculation.spec.ts
+++ b/src/resources/EnergyCalculation.spec.ts
@@ -1,0 +1,148 @@
+import { expect } from "chai";
+
+import examples, { Types, processes } from "./examples";
+import ResourceCollection from "./ResourceCollection";
+import Stock from "./Stock";
+import ResourceCalculation from "./ResourceCalculation";
+import ResourceProcess, { TimeUnit } from "./ResourceProcess";
+import ResourceProcessCollection from "./ResourceProcessCollection";
+import Prosumer from "./Prosumer";
+import EnergyCalculation from "./EnergyCalculation";
+import ProsumerCollection from "./ProsumerCollection";
+
+describe("EnergyCalculation (extended ResourceCalculation) ValueObject", () => {
+  it("should be console printable", () => {
+    const { t3, s3 } = examples;
+    const resources = ResourceCollection.fromArray([t3, s3]);
+    const resourceProcesses = ResourceProcessCollection.fromArray([
+      new ResourceProcess(t3, 1),
+      new ResourceProcess(s3, -1),
+    ]);
+    const stock = new Stock(resources);
+    const prosumers = new ProsumerCollection<Types>([
+      new Prosumer("EnergyProducer", processes.energy),
+      new Prosumer("EnergyProducer", processes.energy),
+      new Prosumer("EnergyProducer", processes.energy),
+    ]);
+    const resourceCalculation = new ResourceCalculation(stock, resourceProcesses);
+    const energyCalculation = new EnergyCalculation(resourceCalculation, prosumers);
+    expect(energyCalculation.productionTable).to.eql([
+      "150/150 energy",
+      "3tumbles(0, Infinity): +1",
+      "3salties(0, Infinity): -1",
+    ]);
+    expect(energyCalculation.prettyProsumers).to.eql([
+      "Prosumer(EnergyProducer, 100%, ResourceProcessCollection[0energy+50])", "Prosumer(EnergyProducer, 100%, ResourceProcessCollection[0energy+50])", "Prosumer(EnergyProducer, 100%, ResourceProcessCollection[0energy+50])",
+    ]);
+    expect(energyCalculation.toString()).to.eql(
+      "Processing energy&resources: 150/150 energy, 3tumbles(0, Infinity): +1, 3salties(0, Infinity): -1",
+    );
+  });
+
+  it("should calculate with time units", () => {
+    const { t3, s3 } = examples;
+    const resources = ResourceCollection.fromArray([t3, s3]);
+    const resourceProcesses = ResourceProcessCollection.fromArray([
+      new ResourceProcess(t3, 1),
+      new ResourceProcess(s3, -1),
+    ]);
+    const stock = new Stock(resources);
+    const resourceCalculation = new ResourceCalculation(stock, resourceProcesses);
+    const prosumers = new ProsumerCollection<Types>([
+      new Prosumer("EnergyProducer", processes.energy),
+    ]);
+    const energyCalculation = new EnergyCalculation(resourceCalculation, prosumers);
+    const timeUnits: TimeUnit = 1;
+
+    const oneSecondLater = energyCalculation.calculate(timeUnits);
+    expect(oneSecondLater.toString()).to.eql(
+      "Processing energy&resources: 50/50 energy, 4tumbles(0, Infinity): +1, 2salties(0, Infinity): -1",
+    );
+
+    const anotherSecondLater = oneSecondLater.calculate(timeUnits);
+    expect(anotherSecondLater.toString()).to.eql(
+      "Processing energy&resources: 50/50 energy, 5tumbles(0, Infinity): +1, 1salties(0, Infinity): -1",
+    );
+
+    const emptySalties = anotherSecondLater.calculate(timeUnits);
+    expect(emptySalties.toString()).to.eql(
+      "Processing energy&resources: 50/50 energy, 6tumbles(0, Infinity): +1, 0salties(0, Infinity): -1",
+    );
+
+    // Continuing with negative rate wont substract any more, because resources can't be negative
+    // At this point we need to recalculate all processes (with adapted rates) especially for energy outage
+    const emptySaltiesStill = emptySalties.calculate(timeUnits);
+    expect(emptySaltiesStill.toString()).to.eql(
+      "Processing energy&resources: 50/50 energy, 7tumbles(0, Infinity): +1, 0salties(0, Infinity): -1",
+    );
+  });
+
+  it("should calculate remaining time units", () => {
+    const { t3, s3 } = examples;
+    const resources = ResourceCollection.fromArray([t3, s3]);
+    const resourceProcesses = ResourceProcessCollection.fromArray([
+      new ResourceProcess(t3, 1),
+      new ResourceProcess(s3, -1),
+    ]);
+    const stock = new Stock(resources);
+    const resourceCalculation = new ResourceCalculation(stock, resourceProcesses);
+    const prosumers = new ProsumerCollection<Types>([]);
+    const energyCalculation = new EnergyCalculation(resourceCalculation, prosumers);
+    const timeUnits: TimeUnit = 3;
+    expect(energyCalculation.validFor).to.be.equal(timeUnits);
+  });
+
+  it("should know how many time units can be calculated within the current limits", () => {
+    const { t3, t5, s3 } = examples;
+    const resources = ResourceCollection.fromArray([t3, s3]);
+    const resourceProcesses = ResourceProcessCollection.fromArray([
+      new ResourceProcess(t5, 2),
+      new ResourceProcess(s3, -1),
+    ]);
+
+    const resourceLimits = ResourceCollection.fromArray([t5, s3]);
+    const limitedStock = new Stock(resources, resourceLimits);
+    const limitedResourceCalculation = new ResourceCalculation(limitedStock, resourceProcesses);
+    const prosumers = new ProsumerCollection<Types>([new Prosumer("Plant", resourceProcesses, 1)]);
+    const energyCalculation = new EnergyCalculation(limitedResourceCalculation, prosumers);
+    const limitedTimeUnits: TimeUnit = 1;
+    expect(energyCalculation.validFor).to.be.equal(limitedTimeUnits);
+    // console.log(`${energyCalculation}:\n${energyCalculation.productionTable}`);
+  });
+
+  it("should know when it is over limits", () => {
+    const { t3, t5, s3 } = examples;
+    const resources = ResourceCollection.fromArray([t3, s3]);
+    const resourceProcesses = ResourceProcessCollection.fromArray([
+      new ResourceProcess(t5, 2.5), // 0.8
+      new ResourceProcess(s3, -1), // 3
+    ]);
+
+    const resourceLimits = ResourceCollection.fromArray([t5, s3]);
+    const limitedStock = new Stock(resources, resourceLimits);
+    const limitedResourceCalculation = new ResourceCalculation(limitedStock, resourceProcesses);
+    const prosumers = new ProsumerCollection<Types>([]);
+    const energyCalculation = new EnergyCalculation(limitedResourceCalculation, prosumers);
+
+    const limitedTimeUnits: TimeUnit = 0; // Actually 0.8, but that's not an integer
+    expect(energyCalculation.validFor).to.be.equal(limitedTimeUnits);
+  });
+
+  it("should know when it is under limits", () => {
+    const { t3, t5, s3 } = examples;
+    const resources = ResourceCollection.fromArray([t3, s3]);
+    const resourceProcesses = ResourceProcessCollection.fromArray([
+      new ResourceProcess(t5, 0.5), // 2 (1*2=5-3)
+      new ResourceProcess(s3, -1), // 3
+    ]);
+
+    const resourceLimits = ResourceCollection.fromArray([t5, s3]);
+    const limitedStock = new Stock(resources, resourceLimits);
+    const limitedResourceCalculation = new ResourceCalculation(limitedStock, resourceProcesses);
+    const prosumers = new ProsumerCollection<Types>([]);
+    const energyCalculation = new EnergyCalculation(limitedResourceCalculation, prosumers);
+
+    const limitedTimeUnits: TimeUnit = 2;
+    expect(energyCalculation.validFor).to.be.equal(limitedTimeUnits);
+  });
+});

--- a/src/resources/EnergyCalculation.ts
+++ b/src/resources/EnergyCalculation.ts
@@ -20,10 +20,9 @@ export default class EnergyCalculation<Types extends ResourceIdentifier> {
     if (!prosumers.isUnbalanced) {
       this.resources = resources;
     } else {
-      //console.log("prosumers are unbalanced - deficit should be applied -", this.balanceFactor);
+      // apply deficit multiplier on imbalanced production
       this.resources = new ResourceCalculation(
         resources.stock,
-        // TODO apply multiplier on production
         prosumers.rebalancedResources(this.balanceFactor),
       );
     }

--- a/src/resources/EnergyCalculation.ts
+++ b/src/resources/EnergyCalculation.ts
@@ -1,0 +1,120 @@
+import type { ResourceIdentifier } from "./Resource";
+import type { TimeUnit } from "./ResourceProcess";;
+import ResourceCalculation from "./ResourceCalculation";
+import ResourceCollection from "./ResourceCollection";
+import ResourceProcess from "./ResourceProcess";
+import type { ResourceProcessCollectionEntries } from "./ResourceProcessCollection";
+import ResourceProcessCollection from "./ResourceProcessCollection";
+import Stock from "./Stock";
+import ProsumerCollection from "./ProsumerCollection";
+
+export default class EnergyCalculation<Types extends ResourceIdentifier> {
+  static REBALANCING_EXPONENT = 1.1;
+
+  readonly resources: ResourceCalculation<Types>;
+
+  readonly prosumers: ProsumerCollection<Types>;
+
+  constructor(resources: ResourceCalculation<Types>, prosumers: ProsumerCollection<Types>) {
+    this.prosumers = prosumers;
+    if (!prosumers.isUnbalanced) {
+      this.resources = resources;
+    } else {
+      //console.log("prosumers are unbalanced - deficit should be applied -", this.balanceFactor);
+      this.resources = new ResourceCalculation(
+        resources.stock,
+        // TODO apply multiplier on production
+        prosumers.rebalancedResources(this.balanceFactor),
+      );
+    }
+  }
+
+  static newStock<ResourceTypes extends ResourceIdentifier>(
+    stock: Stock<ResourceTypes>,
+    prosumers: ProsumerCollection<ResourceTypes>,
+  ) {
+    return new EnergyCalculation<ResourceTypes>(
+      new ResourceCalculation(stock, prosumers.resources),
+      prosumers,
+    );
+  }
+
+  get validFor(): TimeUnit {
+    // as energies just influence the balance after recalculations, this can be simply delegated - until e.g. a heat limit could be reached
+    return this.resources.validFor;
+  }
+
+  get stock(): Stock<Types> {
+    return this.resources.stock;
+  }
+
+  get balanceFactor(): number {
+    return this.prosumers.balanceFactor ** EnergyCalculation.REBALANCING_EXPONENT;
+  }
+
+  hasAvailable(resources: ResourceCollection<Types>) {
+    // TODO check for energy seperately?
+    return this.resources.stock.isFetchable(resources);
+  }
+
+  calculate(timeUnits: TimeUnit) {
+    const resources = this.resources.calculate(timeUnits);
+    return new EnergyCalculation(resources, this.prosumers);
+  }
+
+  get prettyProsumers() {
+    return this.prosumers.map((prosumer) => {
+      return prosumer.toString();
+    });
+  }
+
+  get energies() {
+    const energies = this.prosumers.map((prosumer) => {
+      return prosumer.prosumes.energies;
+    });
+    const limits = energies.reduce((l: ResourceProcessCollectionEntries<Types>, es) => {
+      es.asArray.forEach((energy) => {
+        if (energy.isNegative) {
+          return;
+        }
+        const e = energy.limitFromRate();
+        const limit = l[energy.type] as ResourceProcess<Types>;
+        // eslint-disable-next-line no-param-reassign
+        l[energy.type] = !limit ? e : limit.addLimit(e.limit);
+      });
+      return l;
+    }, {});
+    return ResourceProcessCollection.reduce(energies.map((es) => {
+      return es.addLimits(limits);
+    }));
+  }
+
+  get prettyEnergy(): string[] {
+    return this.energies.map((energy) => {
+      return `${energy.rate}/${energy.limit.amount} ${energy.type}`;
+    });
+  }
+
+  toString() {
+    return `Processing energy&resources: ${this.productionTable.join(", ")}`;
+  }
+
+  /**
+   * Should return entries like this:
+   * - 10energy Prosumer(A, 1, 1) 89/112 or even -58
+   * - 3tumbles(0, 5): +2
+   * - 3salties(0, 3): -1
+   */
+  get productionTable(): string[] {
+    /* const processes = this.resources.stockLimitedProcessCollection.map((process) => {
+      return process.toString();
+    });
+    console.log(this.prettyProsumers);
+    return processes.concat(...this.prettyProsumers, ...this.resources.entries); */
+    const energies = this.prettyEnergy;
+    if (this.balanceFactor < 1) {
+      energies.push(`Degraded to ${Math.round(this.balanceFactor*100)}%`);
+    }
+    return energies.concat(...this.resources.entries);
+  }
+}

--- a/src/resources/EnergyCalculation.ts
+++ b/src/resources/EnergyCalculation.ts
@@ -96,25 +96,27 @@ export default class EnergyCalculation<Types extends ResourceIdentifier> {
   }
 
   toString() {
-    return `Processing energy&resources: ${this.productionTable.join(", ")}`;
+    return `Processing energy&resources: ${this.productionEntries.join(", ")}`;
   }
 
   /**
    * Should return entries like this:
-   * - 10energy Prosumer(A, 1, 1) 89/112 or even -58
+   * - 89/112 energy
    * - 3tumbles(0, 5): +2
    * - 3salties(0, 3): -1
    */
-  get productionTable(): string[] {
-    /* const processes = this.resources.stockLimitedProcessCollection.map((process) => {
-      return process.toString();
-    });
-    console.log(this.prettyProsumers);
-    return processes.concat(...this.prettyProsumers, ...this.resources.entries); */
+  get productionEntries(): string[] {
     const energies = this.prettyEnergy;
     if (this.balanceFactor < 1) {
       energies.push(`Degraded to ${Math.round(this.balanceFactor*100)}%`);
     }
     return energies.concat(...this.resources.entries);
+  }
+
+  get productionTable() {
+    return [
+      ...this.energies.map((energy: ResourceProcess<Types>) => [energy.type, energy.rate, energy.limit.amount]),
+      ...this.resources.table,
+    ];
   }
 }

--- a/src/resources/Prosumer.spec.ts
+++ b/src/resources/Prosumer.spec.ts
@@ -1,0 +1,48 @@
+import { expect } from "chai";
+
+import examples, { energy, process, processes } from "./examples";
+import Prosumer from "./Prosumer";
+
+describe("Prosumer ValueObject", () => {
+  it("should be console printable", () => {
+    const b = new Prosumer("B", processes.rt11s31);
+    expect(b.toString()).to.eql("Prosumer(B, 100%, ResourceProcessCollection[1tumbles+1, 3salties+1])");
+  });
+
+  it("should have resource processes", () => {
+    const speed = 50;
+    const building = new Prosumer("Scraper", processes.rt11s31, speed);
+    // rounding up
+    expect(building.toString()).to.eql("Prosumer(Scraper, 50%, ResourceProcessCollection[1tumbles+1, 3salties+1])");
+    expect(building.at(100).toString()).to.eql(
+      "Prosumer(Scraper, 100%, ResourceProcessCollection[1tumbles+1, 3salties+1])",
+    );
+  });
+
+  it("should ignore over- and underspeed", () => {
+    const b = new Prosumer("B", processes.rt11s31, -2);
+    const b0 = new Prosumer("B", processes.rt11s31, 0);
+    const b2 = new Prosumer("B", processes.rt11s31, 200);
+    expect(b.toString()).to.eql("Prosumer(B, 0%, ResourceProcessCollection[1tumbles+0, 3salties+0])");
+    expect(b0.toString()).to.eql("Prosumer(B, 0%, ResourceProcessCollection[1tumbles+0, 3salties+0])");
+    expect(b2.toString()).to.eql("Prosumer(B, 100%, ResourceProcessCollection[1tumbles+1, 3salties+1])");
+  });
+
+  it("should prosume: consume energy and produce resources", () => {
+    const t = new Prosumer("TumbleFactory", processes.tumbles, 50);
+    expect(t.consumes(energy.e0)?.rate).to.eql(process.ce1.rate / 2);
+    expect(t.produces(examples.t0)?.rate).to.eql(process.pt1.rate / 2);
+  });
+
+  it("should prosume: consume salties and produce energy", () => {
+    const p = new Prosumer("SaltyPowerPlant", processes.prosumption, 100);
+    expect(p.consumes(energy.e0)).to.eql(undefined);
+    expect(p.consumes(examples.s10)).to.eql(process.cs1);
+    expect(p.consumes(examples.t0)).to.eql(undefined);
+    expect(p.produces(energy.e0)).to.eql(process.pe1);
+    expect(p.produces(examples.s10)).to.eql(undefined);
+    expect(p.produces(examples.t0)).to.eql(undefined);
+    expect(p.prosumes).to.eql(processes.prosumption);
+    expect(p.toString()).to.eql("Prosumer(SaltyPowerPlant, 100%, ResourceProcessCollection[10salties-1, 0energy+50])");
+  });
+});

--- a/src/resources/Prosumer.ts
+++ b/src/resources/Prosumer.ts
@@ -1,0 +1,69 @@
+import { process } from "./examples";
+import Energy from "./Energy";
+import Resource, { ResourceIdentifier } from "./Resource";
+import ResourceProcess from "./ResourceProcess";
+import ResourceProcessCollection from "./ResourceProcessCollection";
+
+export type ProsumerType = string | number; // I'd prefer string, but if we want integer unitIDs...
+
+/**
+ * Prosumer is a
+ * Consumer most of the time,
+ * sometimes the opposite: Producer
+ * or even both
+ */
+export default class Prosumer<Types extends ResourceIdentifier> {
+  readonly type: ProsumerType;
+
+  readonly processes: ResourceProcessCollection<Types>;
+
+  /**
+   * Prosumer speed 0-100 percent
+   */
+  readonly speed: number;
+
+  constructor(type: ProsumerType, processes: ResourceProcessCollection<Types>, speed = 100) {
+    this.type = type;
+    this.processes = processes;
+    const defaultSpeed = speed >= 100 ? 100 : speed;
+    this.speed = defaultSpeed <= 0 ? 0 : defaultSpeed;
+  }
+
+  protected new(speed?: number) {
+    return new Prosumer(this.type, this.processes, speed);
+  }
+
+  at(speed: number) {
+    return this.new(speed);
+  }
+
+  consumes(limit: Resource<Types>|Energy<Types>) {
+    const process = this.processes.getByType(limit.type);
+    if (!process || process.rate >= 0) {
+      return undefined;
+    }
+    const rate = (this.speed * process.rate) / 100;
+    return new ResourceProcess(limit, rate);
+  }
+
+  produces(limit: Resource<Types>|Energy<Types>) {
+    const process = this.processes.getByType(limit.type);
+    if (!process || process.rate <= 0) {
+      return undefined;
+    }
+    const rate = (this.speed * process.rate) / 100;
+    return new ResourceProcess(limit, rate);
+  }
+
+  get prosumes(): ResourceProcessCollection<Types> {
+    return this.processes.newRateMultiplier(this.speed / 100);
+  }
+
+  get resources(): ResourceProcessCollection<Types> {
+    return this.processes.resources.newRateMultiplier(this.speed / 100);
+  }
+
+  toString() {
+    return `Prosumer(${this.type}, ${this.speed}%, ${this.prosumes})`;
+  }
+}

--- a/src/resources/ProsumerCollection.spec.ts
+++ b/src/resources/ProsumerCollection.spec.ts
@@ -1,0 +1,44 @@
+import { EnergyResource } from "./examples";
+import { expect } from "chai";
+
+import Prosumer from "./Prosumer";
+import ProsumerCollection from "./ProsumerCollection";
+import ResourceProcess from "./ResourceProcess";
+import ResourceProcessCollection from "./ResourceProcessCollection";
+
+describe("ProsumerCollection ValueObject", () => {
+  it("should be console printable", () => {
+    const collection = new ProsumerCollection([
+      new Prosumer(1, ResourceProcessCollection.fromArray([])),
+      new Prosumer(2, ResourceProcessCollection.fromArray([])),
+    ]);
+    expect(collection.toString()).to.be.eql("ProsumerCollection["
+      + "Prosumer(1, 100%, ResourceProcessCollection[]), "
+      + "Prosumer(2, 100%, ResourceProcessCollection[])"
+      + "]"
+    );
+  });
+
+  it("should return reduced/summed up prosumer resource processes", () => {
+    const collection = new ProsumerCollection([
+      new Prosumer(4, ResourceProcessCollection.fromArray([
+        new ResourceProcess(new EnergyResource(Infinity), 10),
+      ])),
+      new Prosumer(12, ResourceProcessCollection.fromArray([
+        new ResourceProcess(new EnergyResource(Infinity), 10),
+      ])),
+    ]);
+    const reduced = ResourceProcessCollection.fromArray([
+      new ResourceProcess(new EnergyResource(Infinity), 20),
+    ]);
+    expect(collection.reduced).to.eql(reduced);
+  });
+
+  it("should map/filter", () => {
+    const collection = new ProsumerCollection([
+      new Prosumer(1, ResourceProcessCollection.fromArray([])),
+      new Prosumer(2, ResourceProcessCollection.fromArray([])),
+    ]);
+    expect(collection.map((p) => p.type === 1 ? 1 : undefined)).to.eql([1]);
+  });
+});

--- a/src/resources/ProsumerCollection.ts
+++ b/src/resources/ProsumerCollection.ts
@@ -11,11 +11,17 @@ export default class ProsumerCollection<ResourceTypes extends ResourceIdentifier
     this.prosumers = prosumers;
   }
 
+  /**
+   * All non-energy resource processes combined in one collection
+   */
   get resources(): ResourceProcessCollection<ResourceTypes> {
     const processes = this.prosumers.map((p) => p.resources);
     return ResourceProcessCollection.reduce(processes);
   }
 
+  /**
+   * All resource processes combined in one collection
+   */
   get reduced(): ResourceProcessCollection<ResourceTypes> {
     return ResourceProcessCollection.reduce(this.prosumers.map((p) => {
       return p.prosumes;

--- a/src/resources/ProsumerCollection.ts
+++ b/src/resources/ProsumerCollection.ts
@@ -1,0 +1,89 @@
+
+import { ResourceIdentifier } from "./Resource";
+import Prosumer from "./Prosumer";
+import ResourceProcessCollection from "./ResourceProcessCollection";
+
+export default class ProsumerCollection<ResourceTypes extends ResourceIdentifier> {
+
+  readonly prosumers: Prosumer<ResourceTypes>[];
+
+  constructor(prosumers: Prosumer<ResourceTypes>[]) {
+    this.prosumers = prosumers;
+  }
+
+  get resources(): ResourceProcessCollection<ResourceTypes> {
+    const processes = this.prosumers.map((p) => p.resources);
+    return ResourceProcessCollection.reduce(processes);
+  }
+
+  get reduced(): ResourceProcessCollection<ResourceTypes> {
+    return ResourceProcessCollection.reduce(this.prosumers.map((p) => {
+      return p.prosumes;
+    }));
+  }
+
+  get reducedProduction(): ResourceProcessCollection<ResourceTypes> {
+    return ResourceProcessCollection.reduce(this.prosumers.map((p) => {
+      return ResourceProcessCollection.fromArray(p.prosumes.map((process) => {
+        if (process.isNegative) {
+          return undefined;
+        }
+        return process;
+      }));
+    }));
+  }
+
+  get reducedConsumption(): ResourceProcessCollection<ResourceTypes> {
+    return ResourceProcessCollection.reduce(this.prosumers.map((p) => {
+      return ResourceProcessCollection.fromArray(p.prosumes.map((process) => {
+        if (!process.isNegative) {
+          return undefined;
+        }
+        return process;
+      }));
+    }));
+  }
+
+  get isUnbalanced(): boolean {
+    // non energies are irrelevant
+    if (this.reduced.energies.isEmpty) {
+      return false;
+    }
+    return this.balanceFactor < 1;
+  }
+
+  get balanceFactor(): number {
+    const { energies } = this.reduced;
+    const producedEnergy = this.reducedProduction.energies;
+    return energies.asArray.reduce((factor, e) => {
+      if (!e.isNegative) {
+        return factor;
+      }
+      const produced = producedEnergy.get(e.type).rate;
+      const rate = Math.abs(e.rate);
+      // energy quotient
+      return produced / (rate + produced);
+    }, 1);
+  }
+
+  map<GenericReturn>(mappingFunction: (prosumer: Prosumer<ResourceTypes>) => GenericReturn): GenericReturn[] {
+    return this.prosumers.reduce<GenericReturn[]>((entries: GenericReturn[], prosumer: Prosumer<ResourceTypes>) => {
+      const result = mappingFunction(prosumer);
+      if (typeof result === "undefined") {
+        return entries;
+      }
+      entries.push(result);
+      return entries;
+    }, []);
+  }
+
+  rebalancedResources(factor: number): ResourceProcessCollection<ResourceTypes> {
+    // balance factor only affects production of resources
+    const production = this.reducedProduction.resources.newRateMultiplier(factor);
+    return production.add(this.reducedConsumption.resources);
+  }
+
+  toString() {
+    return `ProsumerCollection[${this.prosumers.join(", ")}]`;
+  }
+}

--- a/src/resources/Resource.spec.ts
+++ b/src/resources/Resource.spec.ts
@@ -50,6 +50,7 @@ describe("Resource ValueObject", () => {
       t0, t3, t5, t8, s3,
     } = examples;
     expect(t3.add(t5)).to.be.eql(t8);
+    expect(t3.addAmount(5)).to.be.eql(t8);
     expect(t3.add(t5.infinite)).to.be.eql(t3.infinite);
     expect(t8.subtract(t5)).to.be.eql(t3);
     // 5 - 8 = 0

--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -78,6 +78,10 @@ implements ResourceValue<Type>, ComparableResource<Type> {
     return inf;
   }
 
+  get isInfinite(): boolean {
+    return this.amount === Number.POSITIVE_INFINITY;
+  }
+
   protected checkInfinity(resource?: Resource<Type>): Resource<Type> | false {
     // Need to check for Infinity explicitly, as it's cheated around the constructor
     // which would cast it to in32, result: 0

--- a/src/resources/Resource.ts
+++ b/src/resources/Resource.ts
@@ -1,16 +1,30 @@
-
 export type ResourceIdentifier = string; // i wish^^ = symbol;
-export interface ResourceValue {
-  readonly type: ResourceIdentifier;
+export interface ResourceValue<Type extends ResourceIdentifier> {
+  readonly type: Type;
   readonly amount: number; // int32
+}
+// TODO Why are ResourceValue and ComparableResource interface split anyways? To keep the Value part simple..?
+// TODO Remove code duplicaton in Energy.ts -> Refactor extract AbstractResource class
+export interface ComparableResource<Type extends ResourceIdentifier> {
+  readonly type: Type;
+  equalOfTypeTo(resource: ResourceValue<Type>): boolean;
+  // TODO amount is missing - this is typecast patched in a weird way, just reunite Energy into Resource?
+  equals(resource: ResourceValue<Type>): boolean;
+  isMoreOrEquals(resource: ResourceValue<Type>): boolean;
+  isLessOrEquals(resource: ResourceValue<Type>): boolean;
+  add(resource: ResourceValue<Type>): ComparableResource<Type>;
+  subtract(resource: ResourceValue<Type>): ComparableResource<Type>;
+  times(factor: number): ComparableResource<Type>;
 }
 
 export enum BaseResources {
-  Null = "nulls",
+  Null = "null", // no plural
+  Energy = "energy", // no plural, very special
 }
 
-export default class Resource<Type extends ResourceIdentifier> implements ResourceValue {
-  static types: ResourceIdentifier[] = [BaseResources.Null];
+export default class Resource<Type extends ResourceIdentifier>
+implements ResourceValue<Type>, ComparableResource<Type> {
+  static types: ResourceIdentifier[] = [BaseResources.Null]; // Types are appended in configuration
 
   static Null = new Resource(BaseResources.Null, 0);
 
@@ -34,6 +48,7 @@ export default class Resource<Type extends ResourceIdentifier> implements Resour
    * Create another resource of the same type
    */
   protected new(amount: number) {
+    // Anecdote:
     // Doesn't sound like the best idea considering debugging performance -
     // would be a nice way to not explicitly redeclare this method in every subclass
     /* This makes the new object use the old one as prototype (stores old states in the prototype chain)
@@ -42,6 +57,12 @@ export default class Resource<Type extends ResourceIdentifier> implements Resour
     return resource;
     */
     return new Resource(this.type, amount);
+  }
+
+  /* eslint-disable-next-line class-methods-use-this */
+  get isEnergy() {
+    // Energy implements this with a lookup by type
+    return false;
   }
 
   get zero(): Resource<Type> {
@@ -63,41 +84,45 @@ export default class Resource<Type extends ResourceIdentifier> implements Resour
     if (this.amount === Number.POSITIVE_INFINITY) {
       return this;
     }
-    if (resource && resource.amount === Number.POSITIVE_INFINITY) {
+    if (resource && resource?.amount === Number.POSITIVE_INFINITY) {
       return resource;
     }
     return false;
   }
 
-  equalOfTypeTo(resource: Resource<Type>) {
+  equalOfTypeTo(resource: ResourceValue<Type>) {
     return resource.type === this.type;
   }
 
-  equals(resource: Resource<Type>) {
+  equals(resource: Resource<Type>): boolean {
     return this.equalOfTypeTo(resource)
       // Usually we would need an epsilon to do a float comparison, but since we casted to int32, this works
       && resource.amount === this.amount;
   }
 
-  isMoreOrEquals(resource: Resource<Type>) {
+  isMoreOrEquals(resource: Resource<Type>): boolean {
     if (!this.equalOfTypeTo(resource)) {
       throw new TypeError(`Resource types don't match (${this.type} != ${resource.type})`);
     }
     return this.amount >= resource.amount;
   }
 
-  isLessOrEquals(resource: Resource<Type>) {
+  isLessOrEquals(resource: Resource<Type>): boolean {
     if (!this.equalOfTypeTo(resource)) {
       throw new TypeError(`Resource types don't match (${this.type} != ${resource.type})`);
     }
     return this.amount <= resource.amount;
   }
 
-  add(resource: Resource<Type>) {
+  add(resource: Resource<Type>): Resource<Type> {
     if (!this.equalOfTypeTo(resource)) {
       throw new TypeError(`Resource types don't match (${this.type} != ${resource.type})`);
     }
     return this.checkInfinity(resource) || this.new(this.amount + resource.amount);
+  }
+
+  addAmount(amount: number) {
+    return this.checkInfinity() || this.new(this.amount + amount);
   }
 
   /**
@@ -105,14 +130,14 @@ export default class Resource<Type extends ResourceIdentifier> implements Resour
    * Warning! Returns zero if the result would be negative.
    * @param subtrahend
    */
-  subtract(subtrahend: Resource<Type>) {
+  subtract(subtrahend: Resource<Type>): Resource<Type> {
     if (!this.equalOfTypeTo(subtrahend)) {
       throw new TypeError(`Resource types don't match (${this.type} != ${subtrahend.type})`);
     }
     return this.checkInfinity(subtrahend) || this.new(this.amount - subtrahend.amount);
   }
 
-  times(factor: number) {
+  times(factor: number): Resource<Type> {
     return this.checkInfinity() || this.new(this.amount * factor);
   }
 

--- a/src/resources/ResourceCalculation.spec.ts
+++ b/src/resources/ResourceCalculation.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-import examples from "./examples";
+import examples, { process } from "./examples";
 import ResourceCollection from "./ResourceCollection";
 import Stock from "./Stock";
 import ResourceCalculation from "./ResourceCalculation";
@@ -14,12 +14,13 @@ describe("ResourceCalculation (ResourceCollection with limits) ValueObject", () 
     const processes = ResourceProcessCollection.fromArray([
       new ResourceProcess(t3, 1),
       new ResourceProcess(s3, -1),
+      process.pe1, // this doesn't actually work, that's what EnergyCalculation is for, but it's still printable
     ]);
     const stock = new Stock(resources);
     const resourceCalculation = new ResourceCalculation(stock, processes);
 
     expect(resourceCalculation.toString()).to.eql(
-      "Processing resources: 3tumbles(0, Infinity): +1, 3salties(0, Infinity): -1",
+      "Processing resources: 3tumbles(0, Infinity): +1, 3salties(0, Infinity): -1, 0energy(0, Infinity): +50",
     );
   });
 

--- a/src/resources/ResourceCalculation.ts
+++ b/src/resources/ResourceCalculation.ts
@@ -51,6 +51,14 @@ export default class ResourceCalculation<Types extends ResourceIdentifier> {
     });
   }
 
+  get table() {
+    return this.processes.asArray.map(({ rate, limit }) => {
+      const resource = this.stock.has(limit.type);
+      const limits = this.stock.getResourceLimits(resource);
+      return [resource.type, rate, resource.amount, ...limits];
+    });
+  }
+
   toString() {
     return `Processing resources: ${this.entries.join(", ")}`;
   }

--- a/src/resources/ResourceCalculation.ts
+++ b/src/resources/ResourceCalculation.ts
@@ -31,6 +31,10 @@ export default class ResourceCalculation<Types extends ResourceIdentifier> {
   }
 
   calculate(timeUnits: TimeUnit) {
+    // No need to throw here, resources cannot be negative anyways
+    // if (timeUnits > this.validFor + 1) {
+    // throw new Error(`ResourceCalculation out of validity bounds: ${timeUnits} > ${this.validFor}`); }
+
     const addResources = this.processes.getPositiveResourcesFor(timeUnits);
     const removeResources = this.processes.getNegativeResourcesFor(timeUnits);
     const processes = this.processes.after(timeUnits);
@@ -38,9 +42,9 @@ export default class ResourceCalculation<Types extends ResourceIdentifier> {
     return new ResourceCalculation(stock, processes);
   }
 
-  entriesToString(): string[] {
+  get entries(): string[] {
     return this.processes.asArray.map(({ rate, limit }) => {
-      const resource = this.stock.getResource(limit);
+      const resource = this.stock.has(limit.type);
       const stockLimits = this.stock.resourceLimitToString(resource);
       const ratePrefix = rate > 0 ? "+" : "";
       return `${stockLimits}: ${ratePrefix}${rate}`;
@@ -48,6 +52,6 @@ export default class ResourceCalculation<Types extends ResourceIdentifier> {
   }
 
   toString() {
-    return `Processing resources: ${this.entriesToString().join(", ")}`;
+    return `Processing resources: ${this.entries.join(", ")}`;
   }
 }

--- a/src/resources/ResourceCollection.spec.ts
+++ b/src/resources/ResourceCollection.spec.ts
@@ -68,4 +68,14 @@ describe("ResourceCollection ValueObject", () => {
     const s9c = ResourceCollection.fromArray([s9]);
     expect(s3c.times(3)).to.be.eql(s9c);
   });
+
+  it("can be mapped generically, with a filter on undefined builtin", () => {
+    const { t0, s3 } = examples;
+    const t0c = ResourceCollection.fromArray([t0]);
+    const t0s3c = ResourceCollection.fromArray([t0, s3]);
+    expect(t0c.map((r) => r.amount)).to.be.eql([0]);
+    expect(t0s3c.map((r) => r.amount)).to.be.eql([0, 3]);
+    expect(t0c.map((r) => r.amount || undefined)).to.be.eql([]);
+    expect(t0s3c.map((r) => r.amount || undefined)).to.be.eql([3]);
+  });
 });

--- a/src/resources/ResourceCollection.ts
+++ b/src/resources/ResourceCollection.ts
@@ -1,16 +1,21 @@
 /* eslint class-methods-use-this: "off" */
 import Resource, { ResourceIdentifier } from "./Resource";
+import Energy from "./Energy";
 
 const RESOURCE_COLLECTION_TYPE = "ResourceCollection";
-export type ResourceArray = Resource<ResourceIdentifier>[];
+export type ResourceArray = (Resource<ResourceIdentifier>|Energy<ResourceIdentifier>)[];
 
 export type ResourceCollectionEntries<Types extends ResourceIdentifier> = {
-  [Type in Types]?: Resource<Type>;
+  [Type in Types]?: Resource<Type>|Energy<Type>;
 }
+
+export type ResourceLike<Types extends ResourceIdentifier> = Resource<Types> | Energy<Types>;
+export type ResourcesLike<Types extends ResourceIdentifier> = ResourceLike<Types> | ResourceCollection<Types>;
 
 // Cannot use <Types extends BaseResources>, because
 // TypeScript enums are finite/closed: https://github.com/microsoft/TypeScript/issues/17592#issuecomment-528993663
 export default class ResourceCollection<Types extends ResourceIdentifier> {
+  static TYPE = RESOURCE_COLLECTION_TYPE;
   readonly type = RESOURCE_COLLECTION_TYPE;
 
   readonly entries: ResourceCollectionEntries<Types> = {};
@@ -42,13 +47,36 @@ export default class ResourceCollection<Types extends ResourceIdentifier> {
     }).join(", ");
   }
 
-  getByType<Type extends Types>(type: Type): Resource<Types>|undefined {
+  protected createByType<Type extends Types>(type: Type, amount = 0): ResourceLike<Type> {
+    if (~Energy.types.indexOf(type)) {
+      return new Energy(type, amount);
+    }
+    return new Resource(type, amount);
+  }
+
+  getByType<Type extends Types>(type: Type): ResourceLike<Type>|undefined {
     return this.entries[type];
+  }
+
+  get<Type extends Types>(type: Type): Resource<Type>|Energy<Type> {
+    return this.getByType(type) || this.createByType(type);
+  }
+
+  map<GenericReturn>(mappingFunction: (resource: ResourceLike<Types>, type: Types) => GenericReturn|undefined): GenericReturn[] {
+    return this.types.reduce<GenericReturn[]>((entries: GenericReturn[], type: Types) => {
+      const entry = this.entries[type] as Resource<Types>|Energy<Types>; // Can't cover an undefined typecheck in unit tests as it cannot be undefined
+      const result = mappingFunction(entry, type);
+      if (typeof result === "undefined") {
+        return entries;
+      }
+      entries.push(result);
+      return entries;
+    }, []);
   }
 
   // This makes TypeScript understand if given object is a ResourceCollection or just a Resource
   protected isResourceCollection(
-    resource: Resource<Types> | ResourceCollection<Types>,
+    resource: ResourcesLike<Types>,
   ): resource is ResourceCollection<Types> {
     return resource.type === RESOURCE_COLLECTION_TYPE;
   }
@@ -78,43 +106,43 @@ export default class ResourceCollection<Types extends ResourceIdentifier> {
       if (!compareResource) {
         return false;
       }
-      return resource.equals(compareResource);
+      return resource.equals(compareResource as Resource<Types> & Energy<Types>);
     }, true);
   }
 
-  isMoreOrEquals(resource: Resource<Types> | ResourceCollection<Types>): boolean {
+  isMoreOrEquals(resource: ResourcesLike<Types>): boolean {
     if (!this.isResourceCollection(resource)) {
       const sameType = this.getByType(resource.type);
-      return !!sameType && sameType.isMoreOrEquals(resource);
+      return !!sameType && sameType.isMoreOrEquals(resource as Resource<Types> & Energy<Types>);
     }
     return this.asArray.reduce((isMore: boolean, entry) => {
       const sameType = resource.getByType(entry.type);
-      return isMore && !!sameType && entry.isMoreOrEquals(sameType);
+      return isMore && !!sameType && entry.isMoreOrEquals(sameType as Resource<Types> & Energy<Types>);
     }, true);
   }
 
-  isLessOrEquals(resource: Resource<Types> | ResourceCollection<Types>): boolean {
+  isLessOrEquals(resource: ResourcesLike<Types>): boolean {
     if (!this.isResourceCollection(resource)) {
       const sameType = this.getByType(resource.type);
-      return !sameType || sameType.isLessOrEquals(resource);
+      return !sameType || sameType.isLessOrEquals(resource as Resource<Types> & Energy<Types>);
     }
     return this.asArray.reduce((isLessOrEquals: boolean, entry) => {
       const sameType = resource.getByType(entry.type);
-      return isLessOrEquals && (!sameType || entry.isLessOrEquals(sameType));
+      return isLessOrEquals && (!sameType || entry.isLessOrEquals(sameType as Resource<Types> & Energy<Types>));
     }, true);
   }
 
-  add(resource: Resource<Types> | ResourceCollection<Types>): ResourceCollection<Types> {
+  add(resource: ResourcesLike<Types>): ResourceCollection<Types> {
     if (!this.isResourceCollection(resource)) {
       const sameType = this.entries[resource.type];
       return this.new({
         ...this.entries,
-        [resource.type]: !sameType ? resource : sameType.add(resource),
+        [resource.type]: !sameType ? resource : sameType.add(resource as Resource<Types> & Energy<Types>),
       });
     }
     const resources = this.asArray.map((entry) => {
       const add = resource.getByType(entry.type);
-      return add ? entry.add(add) : entry;
+      return add ? entry.add(add as Resource<Types> & Energy<Types>) : entry;
     }).concat(resource.asArray.filter((res) => {
       return !this.entries[res.type];
     }));
@@ -126,17 +154,17 @@ export default class ResourceCollection<Types extends ResourceIdentifier> {
    * Warning! Returns zero if the result would be negative.
    * @param resource
    */
-  subtract(resource: Resource<Types> | ResourceCollection<Types>): ResourceCollection<Types> {
+  subtract(resource: ResourcesLike<Types>): ResourceCollection<Types> {
     if (!this.isResourceCollection(resource)) {
       const sameType = this.entries[resource.type];
       return this.new({
         ...this.entries,
-        [resource.type]: !sameType ? resource : sameType.subtract(resource),
+        [resource.type]: !sameType ? resource : sameType.subtract(resource as Resource<Types> & Energy<Types>),
       });
     }
     return ResourceCollection.fromArray(this.asArray.map((entry) => {
       const subtract = resource.getByType(entry.type);
-      return subtract ? entry.subtract(subtract) : entry;
+      return subtract ? entry.subtract(subtract as Resource<Types> & Energy<Types>) : entry;
     }));
   }
 

--- a/src/resources/ResourceProcess.spec.ts
+++ b/src/resources/ResourceProcess.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-import examples from "./examples";
+import examples, { energy, process } from "./examples";
 
 import ResourceProcess, { TimeUnit } from "./ResourceProcess";
 
@@ -14,8 +14,10 @@ describe("ResourceProcess ValueObject", () => {
     const infProduction = "tumbles, 0, Infinity";
     expect(infinite.toString()).to.eql(`ResourceProcess[${infProduction}]`);
     const pi = new ResourceProcess(t3, Math.sqrt(Math.PI));
-    const piProd = "tumbles, 1.7724538509055159, 3";
+    const piProd = "tumbles, 2, 3";
     expect(pi.toString()).to.eql(`ResourceProcess[${piProd}]`);
+    const energy = "energy, 50, 0";
+    expect(process.pe1.toString()).to.eql(`ResourceProcess[${energy}]`);
   });
 
   it("should compare resource processes", () => {
@@ -35,11 +37,13 @@ describe("ResourceProcess ValueObject", () => {
     } = examples;
     const t0p = new ResourceProcess(t0, 0);
     const t3p = new ResourceProcess(t3, 3);
-    const t5p = new ResourceProcess(t5, 2.5);
+    const t3p0 = new ResourceProcess(t3, 0);
+    const t5p = new ResourceProcess(t5, 2.5); // 3
     const t8p = new ResourceProcess(t8, 4);
     expect(t0p.endsIn).to.be.equal(infiniteTime);
+    expect(t3p0.endsIn).to.be.equal(infiniteTime);
     expect(t3p.endsIn).to.be.equal(timeUnit);
-    expect(t5p.endsIn).to.be.equal(twoTimeUnits);
+    expect(t5p.endsIn).to.be.equal(timeUnit);
     expect(t8p.endsIn).to.be.equal(twoTimeUnits);
 
     const t8mp = new ResourceProcess(t8, -4);
@@ -47,19 +51,22 @@ describe("ResourceProcess ValueObject", () => {
   });
 
   it("should produce or consume resources over time", () => {
+    const zero: TimeUnit = 0;
     const timeUnit: TimeUnit = 1;
     const twoTimeUnits: TimeUnit = 2;
     const {
-      t0, t3, t5, t8,
+      t0, t3, t5, t6, t8,
     } = examples;
     const t0p = new ResourceProcess(t0, 0);
     const t3p = new ResourceProcess(t3, 3);
     const t5p = new ResourceProcess(t5, 2.5);
     const t8p = new ResourceProcess(t8, -4);
+    const e0p = new ResourceProcess(energy.e0, 0);
     expect(t0p.getResourceFor()).to.be.eql(t0);
+    expect(e0p.getResourceFor(zero)).to.be.eql(energy.e0);
     expect(t0p.getResourceFor(timeUnit)).to.be.eql(t0);
     expect(t3p.getResourceFor(timeUnit)).to.be.eql(t3);
-    expect(t5p.getResourceFor(twoTimeUnits)).to.be.eql(t5);
+    expect(t5p.getResourceFor(twoTimeUnits)).to.be.eql(t6);
     expect(t8p.getResourceFor(twoTimeUnits)).to.be.eql(t8);
   });
 

--- a/src/resources/ResourceProcessCollection.spec.ts
+++ b/src/resources/ResourceProcessCollection.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-import examples from "./examples";
+import examples, { energy, process } from "./examples";
 import ResourceProcess, { TimeUnit } from "./ResourceProcess";
 import ResourceProcessCollection from "./ResourceProcessCollection";
 
@@ -10,11 +10,12 @@ describe("ResourceProcessCollection ValueObject", () => {
     const processes = [
       new ResourceProcess(t3, 0),
       new ResourceProcess(s3, -1),
+      process.ce1,
     ];
-    const t3s3 = ResourceProcessCollection.fromArray(processes);
-    const amount = "3tumbles+0, 3salties-1";
-    expect(t3s3.toString()).to.eql(`ResourceProcessCollection[${amount}]`);
-    expect(t3s3.types).to.eql([t3.type, s3.type]);
+    const t3s3e10 = ResourceProcessCollection.fromArray(processes);
+    const amount = "3tumbles+0, 3salties-1, 0energy-10";
+    expect(t3s3e10.toString()).to.eql(`ResourceProcessCollection[${amount}]`);
+    expect(t3s3e10.types).to.eql([t3.type, s3.type, process.ce1.type]);
   });
 
   it("should compare resource process collections", () => {
@@ -25,7 +26,10 @@ describe("ResourceProcessCollection ValueObject", () => {
     const t3p = new ResourceProcess(t3, 1);
     const t5p = new ResourceProcess(t5, 2);
     const s3p = new ResourceProcess(s3, 3);
+    const s0p0 = new ResourceProcess(s3.zero, 0);
+    const e0p = new ResourceProcess(energy.e0, -10);
     const t0c = ResourceProcessCollection.fromArray([t0p]);
+    const t0e0c = ResourceProcessCollection.fromArray([t0p, e0p]);
     const t3c = ResourceProcessCollection.fromArray([t3p]);
     const t3s3 = ResourceProcessCollection.fromArray([t3p, s3p]);
     const t5s3 = ResourceProcessCollection.fromArray([t5p, s3p]);
@@ -40,6 +44,10 @@ describe("ResourceProcessCollection ValueObject", () => {
     expect(t3c.infinite.equals(t0c)).to.be.false;
     expect(t3c.infinite.equals(t0c.infinite)).to.be.true;
 
+    expect(t3c.get(t3.type)).to.eql(t3p);
+    expect(t3c.get(s3.type)).to.eql(s0p0);
+
+    expect(t0e0c.prettyEnergies).to.be.eql(["0 energy"]);
     /*
     How would we compare limit and or rates?
     expect(t3c.isLessOrEquals(t3)).to.be.true;
@@ -51,13 +59,16 @@ describe("ResourceProcessCollection ValueObject", () => {
     const timeUnit: TimeUnit = 1;
     const twoTimeUnits: TimeUnit = 2;
     const {
-      t3, t5, t8, s3,
+      t0, t3, t5, t8, s3,
     } = examples;
+    const t0p = new ResourceProcess(t0, -0);
     const t3p = new ResourceProcess(t3, 3);
-    const t5p = new ResourceProcess(t5, 2.5);
+    const t5p = new ResourceProcess(t5, 2.5); // 3
+    const t52p = new ResourceProcess(t5, 2.4); // 2
     const t8p = new ResourceProcess(t8, 4);
+    expect(t0p.endsIn).to.be.equal(Infinity);
     expect(t3p.endsIn).to.be.equal(timeUnit);
-    expect(t5p.endsIn).to.be.equal(twoTimeUnits);
+    expect(t5p.endsIn).to.be.equal(timeUnit);
     expect(t8p.endsIn).to.be.equal(twoTimeUnits);
 
     const t8mp = new ResourceProcess(t8, -4);
@@ -67,8 +78,10 @@ describe("ResourceProcessCollection ValueObject", () => {
     const s3p1 = new ResourceProcess(s3, 1);
     const t3s3 = ResourceProcessCollection.fromArray([t3p, s3p]);
     const t5s3 = ResourceProcessCollection.fromArray([t5p, s3p1]);
+    const t52s3 = ResourceProcessCollection.fromArray([t52p, s3p1]);
     expect(t3s3.endsNextIn).to.be.equal(timeUnit);
-    expect(t5s3.endsNextIn).to.be.equal(twoTimeUnits);
+    expect(t5s3.endsNextIn).to.be.equal(timeUnit);
+    expect(t52s3.endsNextIn).to.be.equal(twoTimeUnits);
   });
 
   it("should add and subtract resources processes", () => {
@@ -105,5 +118,17 @@ describe("ResourceProcessCollection ValueObject", () => {
     expect(t3s3.subtract(t3s6)).to.be.eql(t30s30);
     expect(t00.subtract(s3p)).to.be.eql(t0s3n);
     expect(t00.subtract(s3c)).to.be.eql(t0s3n);
+  });
+
+  it("can be mapped generically, with a filter on undefined builtin", () => {
+    const { t0, s3 } = examples;
+    const t0p = new ResourceProcess(t0, 0);
+    const s3p = new ResourceProcess(s3, 3);
+    const t0c = ResourceProcessCollection.fromArray([t0p]);
+    const t0s3c = ResourceProcessCollection.fromArray([t0p, s3p]);
+    expect(t0c.map((r) => r.limit.amount)).to.be.eql([0]);
+    expect(t0s3c.map((r) => r.limit.amount)).to.be.eql([0, 3]);
+    expect(t0c.map((r) => r.limit.amount || undefined)).to.be.eql([]);
+    expect(t0s3c.map((r) => r.limit.amount || undefined)).to.be.eql([3]);
   });
 });

--- a/src/resources/Stock.spec.ts
+++ b/src/resources/Stock.spec.ts
@@ -29,7 +29,7 @@ describe("Stock (ResourceCollection with limits) ValueObject", () => {
     const stock0 = new Stock(ResourceCollection.fromArray([t0]));
     expect(stock.fetch(t3)).to.eql(stock2);
     expect(stock2.store(t3)).to.eql(stock);
-    expect(stock0.getResource(s3)).to.be.eql(s3.zero);
+    expect(stock0.has(s3.type)).to.be.eql(s3.zero);
   });
 
   it("has limits", () => {

--- a/src/resources/Stock.ts
+++ b/src/resources/Stock.ts
@@ -1,5 +1,6 @@
 import Resource, { ResourceIdentifier } from "./Resource";
-import ResourceCollection from "./ResourceCollection";
+import Energy from "./Energy";
+import ResourceCollection, { ResourceLike, ResourcesLike } from "./ResourceCollection";
 
 export default class Stock<Types extends ResourceIdentifier> {
   readonly resources: ResourceCollection<Types>;
@@ -18,32 +19,32 @@ export default class Stock<Types extends ResourceIdentifier> {
     this.min = minCapacity || initial.zero;
   }
 
-  getByType<Type extends Types>(type: Type): Resource<Types>|undefined {
+  getByType<Type extends Types>(type: Type): ResourceLike<Types>|undefined {
     return this.resources.getByType(type);
   }
 
-  getResource(resource: Resource<Types>): Resource<Types> {
-    return this.resources.getByType(resource.type) || resource.zero;
+  has<Type extends Types>(type: Type): ResourceLike<Types> {
+    return this.resources.get(type);
   }
 
   /**
    * Resources which may still fit into until the upper bound it reached
    * @param resource
    */
-  getMaxResource(resource: Resource<Types>): Resource<Types> {
+  getMaxResource(resource: ResourceLike<Types>): ResourceLike<Types> {
     const stocked = this.getByType(resource.type);
     const max = this.max.getByType(resource.type) || resource.infinite;
-    return stocked ? max.subtract(stocked) : max;
+    return stocked ? max.subtract(stocked as Resource<Types> & Energy<Types>) : max;
   }
 
   /**
    * Resources which may still be consumed until lower bound it reached
    * @param resource
    */
-  getMinResource(resource: Resource<Types>): Resource<Types> {
+  getMinResource(resource: ResourceLike<Types>): ResourceLike<Types> {
     const stocked = this.getByType(resource.type);
     const min = this.min.getByType(resource.type) || resource.zero;
-    return stocked ? stocked.subtract(min) : min;
+    return stocked ? stocked.subtract(min as Resource<Types> & Energy<Types>) : min;
   }
 
   protected new(initial: ResourceCollection<Types>) {
@@ -61,6 +62,30 @@ export default class Stock<Types extends ResourceIdentifier> {
     return this.resources.isMoreOrEquals(resources);
   }
 
+  protected isResourceCollection(
+    resources: ResourcesLike<Types>,
+  ): resources is ResourceCollection<Types> {
+    return resources.type === ResourceCollection.TYPE;
+  }
+
+  protected isResource(
+    resource: ResourcesLike<Types>,
+  ): resource is ResourceCollection<Types> {
+    return !this.isResourceCollection(resource) && !resource.isEnergy;
+  }
+
+  getUnfetchable(resources: ResourceCollection<Types>) {
+    return ResourceCollection.fromArray<Types>(resources.map((resource) => {
+      if (!this.isResource(resource)) {
+        return undefined;
+      }
+      if (this.isFetchable(resource)) {
+        return undefined;
+      }
+      return resource;
+    }));
+  }
+
   isStorable(resources: Resource<Types> | ResourceCollection<Types>) {
     return this.resources.add(resources).isLessOrEquals(this.max);
   }
@@ -73,19 +98,19 @@ export default class Stock<Types extends ResourceIdentifier> {
     return this.new(this.resources.subtract(resources));
   }
 
-  resourceLimitToString(resource: Resource<Types>) {
+  resourceLimitToString(resource: ResourceLike<Types>) {
     const min = this.min.getByType(resource.type) || resource.zero;
     const max = this.max.getByType(resource.type) || resource.infinite;
     return `${resource.prettyAmount}(${min.amount}, ${max.amount})`;
   }
 
-  limitedAmountsToString(): string[] {
+  get limitedAmounts(): string[] {
     return this.resources.asArray.map((resource) => {
       return this.resourceLimitToString(resource);
     });
   }
 
   toString() {
-    return `Stock[${this.limitedAmountsToString().join(", ")}]`;
+    return `Stock[${this.limitedAmounts.join(", ")}]`;
   }
 }

--- a/src/resources/Stock.ts
+++ b/src/resources/Stock.ts
@@ -99,9 +99,14 @@ export default class Stock<Types extends ResourceIdentifier> {
   }
 
   resourceLimitToString(resource: ResourceLike<Types>) {
+    const [min, max] = this.getResourceLimits(resource);
+    return `${resource.prettyAmount}(${min}, ${max})`;
+  }
+
+  getResourceLimits(resource: ResourceLike<Types>) {
     const min = this.min.getByType(resource.type) || resource.zero;
     const max = this.max.getByType(resource.type) || resource.infinite;
-    return `${resource.prettyAmount}(${min.amount}, ${max.amount})`;
+    return [min.amount, max.amount];
   }
 
   get limitedAmounts(): string[] {

--- a/src/resources/examples.ts
+++ b/src/resources/examples.ts
@@ -1,20 +1,40 @@
-/* eslint max-classes-per-file: "off" */
-import Resource, { BaseResources } from "./Resource";
+/* eslint-disable max-classes-per-file, arrow-body-style */
+import {
+  BaseResources,
+  Energy,
+  Resource,
+  ResourceCollection,
+  ResourceProcess,
+  ResourceProcessCollection,
+} from ".";
 
+// Let's invent some example replacement resource and energy types
 export enum ResourceTypes {
   // ...BaseResources,
   Tumble = "tumbles",
   Salty = "salties",
+  Blubber = "blubbs",
 }
 
-export type Types = ResourceTypes | BaseResources;
+export enum EnergyTypes {
+  Electricity = "energy",
+  Heat = "heat",
+}
+
+export type Types = ResourceTypes | EnergyTypes | BaseResources;
 
 // Add new resources to known resource types
 const newResourceTypes: Types[] = [
   ResourceTypes.Tumble,
   ResourceTypes.Salty,
+  ResourceTypes.Blubber,
+];
+const newEnergyTypes: Types[] = [
+  EnergyTypes.Electricity,
+  EnergyTypes.Heat,
 ];
 Resource.types.push(...newResourceTypes);
+Energy.types.push(...newEnergyTypes);
 
 export class TumbleResource extends Resource<ResourceTypes.Tumble> {
   constructor(amount: number) {
@@ -27,19 +47,132 @@ export class SaltyResource extends Resource<ResourceTypes.Salty> {
     super(ResourceTypes.Salty, amount);
   }
 }
+export class BlubbResource extends Resource<ResourceTypes.Blubber> {
+  constructor(amount: number) {
+    super(ResourceTypes.Blubber, amount);
+  }
+}
+
+export class EnergyResource extends Energy<EnergyTypes.Electricity> {
+  constructor(amount: number) {
+    super(EnergyTypes.Electricity, amount);
+  }
+}
+/**
+ * Heat as another energy example type, yes!
+ * Geoengineering allows to change a planets temperature for example, which has a huge impact on the ecology
+ * The game physics of temperature could be similar to energy level
+ */
+export class HeatResource extends Energy<EnergyTypes.Heat> {
+  constructor(amount: number) {
+    super(EnergyTypes.Heat, amount);
+  }
+}
 
 export type ResourceType = TumbleResource | SaltyResource | BaseResources;
+export type EnergyType = EnergyResource;
 
 const t0 = new TumbleResource(0);
+const t1 = new TumbleResource(1);
+const t3 = new TumbleResource(3);
+const s0 = new SaltyResource(0);
+const s3 = new SaltyResource(3);
+const b1 = new BlubbResource(1);
 const examples: {[name: string]: Resource<Types>} = {
   t0,
-  t1: new TumbleResource(1),
-  t3: new TumbleResource(3),
+  t1,
+  t3,
   t5: new TumbleResource(5),
+  t6: new TumbleResource(6),
   t8: new TumbleResource(8),
-  s3: new SaltyResource(3),
+  s0,
+  s3,
   s6: new SaltyResource(6),
   s9: new SaltyResource(9),
+  s10: new SaltyResource(10),
+  b1,
+  b15: new BlubbResource(15),
 };
 
 export default examples;
+
+export const resources: {[name: string]: ResourceCollection<Types>} = {
+  t3s3: ResourceCollection.fromArray([t3, s3]),
+};
+const e0 = new EnergyResource(0);
+export const energy: {[name: string]: Energy<Types>} = {
+  em10: new EnergyResource(-10),
+  e0,
+  e10: new EnergyResource(10),
+  e100: new EnergyResource(100),
+  eInf: e0.infinite,
+  h0: new HeatResource(0),
+  h10: new HeatResource(10),
+};
+
+export const production = {
+  [ResourceTypes.Tumble]: (lvl: number) => 30 * lvl * lvl ** 1.1,
+  [ResourceTypes.Salty]: (lvl: number) => 20 * lvl * lvl ** 1.1,
+  [EnergyTypes.Electricity]: (lvl: number) => 50 * lvl * lvl ** 1.1,
+};
+
+export const consumption = {
+  [ResourceTypes.Salty]: (lvl: number) => -10 * lvl * lvl ** 1.1,
+  [EnergyTypes.Electricity]: (lvl: number) => -10 * lvl * lvl ** 1.1,
+};
+
+const rt11 = new ResourceProcess(t1, 1);
+const rt31 = new ResourceProcess(t3, 1);
+const rs31 = new ResourceProcess(s3, 1);
+const rb11 = new ResourceProcess(b1, 1);
+
+const ps1 = new ResourceProcess(
+  new Resource(
+    ResourceTypes.Salty,
+    production[ResourceTypes.Salty](1),
+  ),
+  1,
+);
+const pe1 = new ResourceProcess(
+  e0, // or energy.eInf?,
+  production[EnergyTypes.Electricity](1),
+);
+const pt1 = new ResourceProcess(
+  t0,
+  production[ResourceTypes.Tumble](1),
+);
+const saltyConsumption10 = new SaltyResource(
+  -consumption[ResourceTypes.Salty](1),
+);
+const cs1 = new ResourceProcess(
+  saltyConsumption10,
+  -1,
+);
+const ce1 = new ResourceProcess(
+  e0,
+  consumption[EnergyTypes.Electricity](1),
+);
+
+export const process: {[name: string]: ResourceProcess<Types>} = {
+  rt11,
+  rt31,
+  rs31,
+  rb11,
+  pt1,
+  ps1,
+  pe1,
+  cs1,
+  ce1,
+};
+
+// salty up, energy up, salty down
+const proRes = [ps1, pe1, cs1];
+
+export const processes: {[name: string]: ResourceProcessCollection<Types>} = {
+  rt11s31: ResourceProcessCollection.fromArray([rt11, rs31]),
+  rt31s31: ResourceProcessCollection.fromArray([rt31, rs31]),
+  rt31s31b11: ResourceProcessCollection.fromArray([rt31, rs31, rb11]),
+  tumbles: ResourceProcessCollection.fromArray<Types>([ce1, pt1]),
+  energy: ResourceProcessCollection.fromArray<Types>([pe1]),
+  prosumption: ResourceProcessCollection.fromArray<Types>(proRes),
+};

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,13 +1,16 @@
-import Resource from "./Resource";
-import ResourceCalculation from "./ResourceCalculation";
-import ResourceCollection from "./ResourceCollection";
-import ResourceProcess from "./ResourceProcess";
-import ResourceProcessCollection from "./ResourceProcessCollection";
-
-export default {
-  Resource,
-  ResourceCollection,
-  ResourceProcess,
-  ResourceProcessCollection,
-  ResourceCalculation,
-};
+export {
+  default as Resource,
+} from "./Resource";
+export type {
+  ResourceIdentifier,
+  ResourceValue,
+  BaseResources,
+} from "./Resource";
+// export { default as ResourceCalculation } from "./ResourceCalculation";
+export { default as ResourceCollection } from "./ResourceCollection";
+export { default as ResourceProcess } from "./ResourceProcess";
+export { default as ResourceProcessCollection } from "./ResourceProcessCollection";
+export { default as Stock } from "./Stock";
+export { default as Prosumer } from "./Prosumer";
+export { default as Energy } from "./Energy";
+export { default as EnergyCalculation } from "./EnergyCalculation";


### PR DESCRIPTION
Add new Entities: Factory, FactoryEnvironment
Add new ValueObjects: Building, Prosumer, Energy, EnergyCalculation

- Factory Energy ✔
- Add energy outage handling strategies ✔
- Tests, Coverage (keep it at 100%) ✔

Questionable:
Energy is still a copy from Resource, should it be the same class? Are the generics BuildingType and ResourceType useless or is it nice to use configurable TypeScript enums?

There are still many Todos left but the PR is already quite big and the next refactors are out of scope.
The next steps are to add BuildingProcesses and the main entity to encapsulate resources and buildings and exporting the engine package for a simple console UI.

Rebased and squashed after npm audit

